### PR TITLE
Fix for projects that reference Analytics and Maps.

### DIFF
--- a/Google.Analytics/component/component.yaml
+++ b/Google.Analytics/component/component.yaml
@@ -1,4 +1,4 @@
-version: 3.14.0.4
+version: 3.14.0.5
 name: Google Analytics for iOS
 id: googleiosanalytics
 publisher: Xamarin Inc.
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-    - Xamarin.Google.iOS.Analytics, Version=3.14.0.4
+    - Xamarin.Google.iOS.Analytics, Version=3.14.0.5
 samples:
   - name: "Cute Animals Sample"
     path:  ../samples/CuteAnimalsiOS/CuteAnimalsiOS.sln

--- a/Google.Analytics/nuget/Xamarin.Google.iOS.Analytics.nuspec
+++ b/Google.Analytics/nuget/Xamarin.Google.iOS.Analytics.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.Analytics</id>
     <title>Google APIs Analytics iOS Library</title>
-    <version>3.14.0.4</version>
+    <version>3.14.0.5</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Google.Analytics/source/Google.Analytics/Google.Analytics.targets
+++ b/Google.Analytics/source/Google.Analytics/Google.Analytics.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 	<PropertyGroup>
-		<_GoogleMapsAssemblyName>Google.Analytics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleMapsAssemblyName>
+		<_GoogleAnalyticsAssemblyName>Google.Analytics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleAnalyticsAssemblyName>
 		<_GoogleAnalyticsItemsFolder>GAnlytcs-3.14</_GoogleAnalyticsItemsFolder>
 	</PropertyGroup>
 
@@ -19,7 +19,7 @@
 
 			<RestoreAssemblyResource Include="$(XamarinBuildDownloadDir)$(_GoogleAnalyticsItemsFolder)\Libraries\libGoogleAnalytics.a">
 				<LogicalName>libGoogleAnalytics.a</LogicalName>
-				<AssemblyName>$(_GoogleMapsAssemblyName)</AssemblyName>
+				<AssemblyName>$(_GoogleAnalyticsAssemblyName)</AssemblyName>
 			</RestoreAssemblyResource>
 
 		</ItemGroup>


### PR DESCRIPTION
The assembly name property on the Analytics targets file
was using the same name as the maps assembly name.

This would cause all Maps resources to be embedded in the
Analytics dll and a linker error for Google Maps was observed.