### PR TITLE
Updated to version 7.11.0.

### DIFF
--- a/Google.MobileAds/component/component.yaml
+++ b/Google.MobileAds/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.8.1.1
+version: 7.11.0
 name: Google Mobile Ads for iOS
 id: googleiosmobileads
 publisher: Xamarin Inc
@@ -14,7 +14,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-    - Xamarin.Google.iOS.MobileAds, Version=7.8.1.1
+    - Xamarin.Google.iOS.MobileAds, Version=7.11.0
 samples:
   - name: "Google Mobile Ads AdMob Sample"
     path:  ../samples/MobileAdsExample/MobileAdsExample.sln

--- a/Google.MobileAds/externals/Podfile
+++ b/Google.MobileAds/externals/Podfile
@@ -4,5 +4,5 @@ platform :ios, '6.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'Google-Mobile-Ads-SDK' do
-  pod 'Google-Mobile-Ads-SDK', '7.8.1'
+  pod 'Google-Mobile-Ads-SDK', '7.11'
 end

--- a/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
+++ b/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.MobileAds</id>
     <title>Google APIs Mobile Ads iOS Library</title>
-    <version>7.8.1.1</version>
+    <version>7.11.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
+++ b/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
@@ -2,12 +2,12 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleMobileAdsAssemblyName>Google.MobileAds, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleMobileAdsAssemblyName>
-		<_GoogleMobileAdsId>Gmbladssdk-7.8.1</_GoogleMobileAdsId>
+		<_GoogleMobileAdsId>Gmbladssdk-7.11.0</_GoogleMobileAdsId>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildRestoreResources Include="_GoogleMobileAdsItems" />
 		<XamarinBuildDownload Include="$(_GoogleMobileAdsId)">
-			<Url>https://www.gstatic.com/cpdc/1dbc5a8a168d6314-Google-Mobile-Ads-SDK-7.8.1.tar.gz</Url>
+			<Url>https://www.gstatic.com/cpdc/1f35d1cbe636d847-Google-Mobile-Ads-SDK-7.11.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 	</ItemGroup>

--- a/Google.MobileAds/source/Google.MobileAds/GoogleMobileAds.linkwith.cs
+++ b/Google.MobileAds/source/Google.MobileAds/GoogleMobileAds.linkwith.cs
@@ -4,7 +4,7 @@ using ObjCRuntime;
 [assembly: LinkWith ("GoogleMobileAds",
 	LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Arm64 | LinkTarget.Simulator | LinkTarget.Simulator64,
 	LinkerFlags = "-ObjC",
-	Frameworks = "AudioToolbox AVFoundation CoreBluetooth CoreGraphics CoreMedia CoreTelephony EventKit EventKitUI MediaPlayer MessageUI QuartzCore StoreKit SystemConfiguration",
+	Frameworks = "AudioToolbox AVFoundation CoreGraphics CoreMedia CoreMotion CoreTelephony CoreVideo Foundation GLKit MediaPlayer MessageUI MobileCoreServices OpenGLES StoreKit SystemConfiguration UIKit",
         WeakFrameworks = "AdSupport SafariServices",
 	ForceLoad = true,
 	SmartLink = true)]


### PR DESCRIPTION
Updated to version 7.11.0.

Currently without any ApiDefinition changes - this is meant as a quick fix for the iOS 10 error on submit:

> This app attempts to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSCalendarsUsageDescription key with a string value explaining to the user how the app uses this data.

> This app attempts to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSMotionUsageDescription key with a string value explaining to the user how the app uses this data.

See:

https://forums.developer.apple.com/thread/62229

And:

https://firebase.google.com/docs/admob/release-notes