### PR TITLE
Google Tag Manager - Fixed dependencies

### DIFF
--- a/Google.TagManager/component/component.yaml
+++ b/Google.TagManager/component/component.yaml
@@ -1,4 +1,4 @@
-version: 5.0.8.0
+version: 5.0.8.1
 name: Google Tag Manager for iOS
 id: googleiostagmanager
 publisher: Xamarin Inc.
@@ -19,7 +19,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-    - Xamarin.Google.iOS.TagManager, Version=5.0.8.0
+    - Xamarin.Google.iOS.TagManager, Version=5.0.8.1
 samples:
   - name: "Tag Manager Sample"
     path:  ../samples/TagManagerSample/TagManagerSample.sln

--- a/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
+++ b/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.TagManager</id>
     <title>Google APIs Tag Manager iOS Library</title>
-    <version>5.0.8.0</version>
+    <version>5.0.8.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Google.TagManager/source/Google.TagManager/Google.TagManager.targets
+++ b/Google.TagManager/source/Google.TagManager/Google.TagManager.targets
@@ -5,7 +5,6 @@
 		<_GoogleTagManagerAssemblyName>Google.TagManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleTagManagerAssemblyName>
 		<_GoogleTagManagerItemsFolder>GTagM-5.0.8</_GoogleTagManagerItemsFolder>
 		<_GoogleUtilitiesItemsFolder>GUtlts-1.3.2</_GoogleUtilitiesItemsFolder>
-		<_GoogleSymbolUtilitiesItemsFolder>GSmblU-1.1.2</_GoogleSymbolUtilitiesItemsFolder>
 	</PropertyGroup>
 
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
@@ -17,10 +16,6 @@
 			<Url>https://dl.google.com/dl/cpdc/978f81964b50a7c0/GoogleUtilities-1.3.2.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
-		<XamarinBuildDownload Include="$(_GoogleSymbolUtilitiesItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/7ecdffda6fbef4af/GoogleSymbolUtilities-1.1.2.tar.gz</Url>
-			<Kind>Tgz</Kind>
-		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_GoogleTagManagerItems"/>
 	</ItemGroup>
 
@@ -29,7 +24,6 @@
 		<PropertyGroup>
 			<_GoogleTagManagerSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleTagManagerItemsFolder)\Frameworks\</_GoogleTagManagerSDKBaseFolder>
 			<_GoogleUtilitiesSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleUtilitiesItemsFolder)\Frameworks\frameworks\</_GoogleUtilitiesSDKBaseFolder>
-			<_GoogleSymbolUtilitiesSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleSymbolUtilitiesItemsFolder)\Frameworks\frameworks\</_GoogleSymbolUtilitiesSDKBaseFolder>
 		</PropertyGroup>
 
 		<ItemGroup>
@@ -43,10 +37,6 @@
 			</RestoreAssemblyResource>
 			<RestoreAssemblyResource Include="$(_GoogleUtilitiesSDKBaseFolder)GoogleUtilities.framework\GoogleUtilities">
 				<LogicalName>GoogleUtilities</LogicalName>
-				<AssemblyName>$(_GoogleTagManagerAssemblyName)</AssemblyName>
-			</RestoreAssemblyResource>
-			<RestoreAssemblyResource Include="$(_GoogleSymbolUtilitiesSDKBaseFolder)GoogleSymbolUtilities.framework\GoogleSymbolUtilities">
-				<LogicalName>GoogleSymbolUtilities</LogicalName>
 				<AssemblyName>$(_GoogleTagManagerAssemblyName)</AssemblyName>
 			</RestoreAssemblyResource>
 		</ItemGroup>


### PR DESCRIPTION
* Removed GoogleSymbolUtilities dependency, due its reference in Firebase.Analytics