### PR TITLE
Firebase APIs for iOS 4.3.0

### DIFF
--- a/Firebase.AdMob/component/component.yaml
+++ b/Firebase.AdMob/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.21.0.0
+version: 7.21.0.1
 name: Firebase AdMob for iOS
 id: firebaseiosadmob
 publisher: Xamarin Inc
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.AdMob, Version=7.21.0.0
+  - Xamarin.Firebase.iOS.AdMob, Version=7.21.0.1
 samples:
 - name: AdMob Sample
   path: ../samples/AdMobSample/AdMobSample.sln

--- a/Firebase.AdMob/component/component.yaml
+++ b/Firebase.AdMob/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.21.0.1
+version: 7.24.1.0
 name: Firebase AdMob for iOS
 id: firebaseiosadmob
 publisher: Xamarin Inc
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.AdMob, Version=7.21.0.1
+  - Xamarin.Firebase.iOS.AdMob, Version=7.24.1.0
 samples:
 - name: AdMob Sample
   path: ../samples/AdMobSample/AdMobSample.sln

--- a/Firebase.AdMob/externals/Podfile
+++ b/Firebase.AdMob/externals/Podfile
@@ -1,27 +1,27 @@
 =begin
 Last run Firebase/AdMob installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseInstanceID (2.0.0)
-- Google-Mobile-Ads-SDK (7.21.0)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseInstanceID (2.0.4)
+- Google-Mobile-Ads-SDK (7.24.1)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Google.MobileAds binding, you can find:
-- Google-Mobile-Ads-SDK (7.21.0)
+- Google-Mobile-Ads-SDK (7.24.1)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -30,5 +30,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseAdMob' do
-	pod 'Firebase/AdMob', '4.0.3'
+	pod 'Firebase/AdMob', '4.3.0'
 end

--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -18,7 +18,7 @@
         <dependency id="Xamarin.Google.iOS.MobileAds" version="7.21.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.AdMob</id>
     <title>Firebase APIs AdMob iOS Library</title>
-    <version>7.21.0.0</version>
+    <version>7.21.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -16,8 +16,8 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.MobileAds" version="7.21.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.MobileAds" version="7.21.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.AdMob</id>
     <title>Firebase APIs AdMob iOS Library</title>
-    <version>7.21.0.1</version>
+    <version>7.24.1.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.21.0.0" />
+        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.24.1.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />

--- a/Firebase.Analytics/component/component.yaml
+++ b/Firebase.Analytics/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.2.0
+version: 4.0.2.1
 name: Firebase Analytics for iOS
 id: firebaseiosanalytics
 publisher: Xamarin Inc.
@@ -17,7 +17,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Analytics, Version=4.0.2.0
+  - Xamarin.Firebase.iOS.Analytics, Version=4.0.2.1
 samples:
 - name: Analytics Sample
   path: ../samples/AnalyticsSample/AnalyticsSample.sln

--- a/Firebase.Analytics/component/component.yaml
+++ b/Firebase.Analytics/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.2.1
+version: 4.0.4.0
 name: Firebase Analytics for iOS
 id: firebaseiosanalytics
 publisher: Xamarin Inc.
@@ -17,7 +17,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Analytics, Version=4.0.2.1
+  - Xamarin.Firebase.iOS.Analytics, Version=4.0.4.0
 samples:
 - name: Analytics Sample
   path: ../samples/AnalyticsSample/AnalyticsSample.sln

--- a/Firebase.Analytics/externals/Podfile
+++ b/Firebase.Analytics/externals/Podfile
@@ -1,27 +1,24 @@
 =begin
 Last run FirebaseAnalytics installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseInstanceID (2.0.0)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseInstanceID (2.0.4)
+- GoogleToolboxForMac (2.1.3)
+- nanopb (0.3.8)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -30,5 +27,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseAnalytics' do
-	pod 'Firebase/Analytics', '4.0.3'
+	pod 'Firebase/Analytics', '4.3.0'
 end

--- a/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
+++ b/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
+++ b/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Analytics</id>
     <title>Firebase APIs Analytics iOS Library</title>
-    <version>4.0.2.0</version>
+    <version>4.0.2.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
+++ b/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Analytics</id>
     <title>Firebase APIs Analytics iOS Library</title>
-    <version>4.0.2.1</version>
+    <version>4.0.4.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.Analytics/source/Firebase.Analytics/Firebase.Analytics.targets
+++ b/Firebase.Analytics/source/Firebase.Analytics/Firebase.Analytics.targets
@@ -3,12 +3,12 @@
 
 	<PropertyGroup>
 		<_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
-		<_FirebaseAnalyticsItemsFolder>FAnlytcs-4.0.2</_FirebaseAnalyticsItemsFolder>
+		<_FirebaseAnalyticsItemsFolder>FAnlytcs-4.0.4</_FirebaseAnalyticsItemsFolder>
 	</PropertyGroup>
 
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseAnalyticsItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/cd09c0dd441ae346/FirebaseAnalytics-4.0.2.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/15a4dd6c971f8bbf/FirebaseAnalytics-4.0.4.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseAnalyticsItems"/>

--- a/Firebase.Auth/component/component.yaml
+++ b/Firebase.Auth/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.0.0
+version: 4.0.0.1
 name: Firebase Auth for iOS
 id: firebaseiosauth
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Auth, Version=4.0.0.0
+  - Xamarin.Firebase.iOS.Auth, Version=4.0.0.1
 samples:
 - name: Auth Sample
   path: ../samples/AuthSample/AuthSample.sln

--- a/Firebase.Auth/component/component.yaml
+++ b/Firebase.Auth/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.0.1
+version: 4.2.1.0
 name: Firebase Auth for iOS
 id: firebaseiosauth
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Auth, Version=4.0.0.1
+  - Xamarin.Firebase.iOS.Auth, Version=4.2.1.0
 samples:
 - name: Auth Sample
   path: ../samples/AuthSample/AuthSample.sln

--- a/Firebase.Auth/externals/Podfile
+++ b/Firebase.Auth/externals/Podfile
@@ -1,31 +1,29 @@
 =begin
 Last run FirebaseAuth installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseAuth (4.0.0)
-- FirebaseCore (4.0.3)
-- FirebaseInstanceID (2.0.0)
-- GTMSessionFetcher (1.1.9)
-- GoogleNetworkingUtilities (1.2.2)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseAuth (4.2.1)
+- FirebaseCore (4.0.8)
+- FirebaseInstanceID (2.0.4)
+- GTMSessionFetcher (1.1.12)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.Auth binding, you can find:
-- FirebaseAuth (4.0.0)
-- GoogleNetworkingUtilities (1.2.2)
+- FirebaseAuth (4.2.1)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
-- GTMSessionFetcher (1.1.9)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
+- GTMSessionFetcher (1.1.12)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -34,5 +32,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseAuth' do
-	pod 'Firebase/Auth', '4.0.3'
+	pod 'Firebase/Auth', '4.3.0'
 end

--- a/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
+++ b/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Auth</id>
     <title>Firebase APIs Auth iOS Library</title>
-    <version>4.0.0.1</version>
+    <version>4.2.1.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
+++ b/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Auth</id>
     <title>Firebase APIs Auth iOS Library</title>
-    <version>4.0.0.0</version>
+    <version>4.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
+++ b/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
+++ b/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Auth/source/Firebase.Auth/ApiDefinition.cs
+++ b/Firebase.Auth/source/Firebase.Auth/ApiDefinition.cs
@@ -20,8 +20,9 @@ namespace Firebase.Auth
 		bool HandleCodeInApp { get; set; }
 
 		// @property (readonly, copy, nonatomic) NSString * _Nullable iOSBundleID;
+		// -(void)setIOSBundleID:(NSString * _Nonnull)iOSBundleID;
 		[NullAllowed, Export ("iOSBundleID")]
-		string IOSBundleId { get; }
+		string IOSBundleId { get; set; }
 
 		// @property (readonly, copy, nonatomic) NSString * _Nullable androidPackageName;
 		[NullAllowed, Export ("androidPackageName")]
@@ -34,10 +35,6 @@ namespace Firebase.Auth
 		// @property (readonly, assign, nonatomic) BOOL androidInstallIfNotAvailable;
 		[Export ("androidInstallIfNotAvailable")]
 		bool AndroidInstallIfNotAvailable { get; }
-
-		// -(void)setIOSBundleID:(NSString * _Nonnull)iOSBundleID;
-		[Export ("setIOSBundleID:")]
-		void SetiOSBundleId (string iOSBundleId);
 
 		// -(void)setAndroidPackageName:(NSString * _Nonnull)androidPackageName installIfNotAvailable:(BOOL)installIfNotAvailable minimumVersion:(NSString * _Nullable)minimumVersion;
 		[Export ("setAndroidPackageName:installIfNotAvailable:minimumVersion:")]
@@ -309,7 +306,7 @@ namespace Firebase.Auth
 		// @required -(void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^ _Nullable)(void))completion;
 		[Abstract]
 		[Export ("dismissViewControllerAnimated:completion:")]
-		void DismissViewControllerAnimated (bool flag, [NullAllowed] Action completion);
+		void DismissViewController (bool animated, [NullAllowed] Action completion);
 	}
 
 	// @interface FIREmailAuthProvider : NSObject

--- a/Firebase.Auth/source/Firebase.Auth/ApiDefinition.cs
+++ b/Firebase.Auth/source/Firebase.Auth/ApiDefinition.cs
@@ -7,6 +7,43 @@ using CoreGraphics;
 
 namespace Firebase.Auth
 {
+	// @interface FIRActionCodeSettings : NSObject
+	[BaseType (typeof (NSObject), Name = "FIRActionCodeSettings")]
+	interface ActionCodeSettings
+	{
+		// @property (copy, nonatomic) NSURL * _Nullable URL;
+		[NullAllowed, Export ("URL", ArgumentSemantic.Copy)]
+		NSUrl Url { get; set; }
+
+		// @property (assign, nonatomic) BOOL handleCodeInApp;
+		[Export ("handleCodeInApp")]
+		bool HandleCodeInApp { get; set; }
+
+		// @property (readonly, copy, nonatomic) NSString * _Nullable iOSBundleID;
+		[NullAllowed, Export ("iOSBundleID")]
+		string IOSBundleId { get; }
+
+		// @property (readonly, copy, nonatomic) NSString * _Nullable androidPackageName;
+		[NullAllowed, Export ("androidPackageName")]
+		string AndroidPackageName { get; }
+
+		// @property (readonly, copy, nonatomic) NSString * _Nullable androidMinimumVersion;
+		[NullAllowed, Export ("androidMinimumVersion")]
+		string AndroidMinimumVersion { get; }
+
+		// @property (readonly, assign, nonatomic) BOOL androidInstallIfNotAvailable;
+		[Export ("androidInstallIfNotAvailable")]
+		bool AndroidInstallIfNotAvailable { get; }
+
+		// -(void)setIOSBundleID:(NSString * _Nonnull)iOSBundleID;
+		[Export ("setIOSBundleID:")]
+		void SetiOSBundleId (string iOSBundleId);
+
+		// -(void)setAndroidPackageName:(NSString * _Nonnull)androidPackageName installIfNotAvailable:(BOOL)installIfNotAvailable minimumVersion:(NSString * _Nullable)minimumVersion;
+		[Export ("setAndroidPackageName:installIfNotAvailable:minimumVersion:")]
+		void SetAndroidPackageName (string androidPackageName, bool installIfNotAvailable, [NullAllowed] string minimumVersion);
+	}
+
 	// @interface FIRAdditionalUserInfo : NSObject
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRAdditionalUserInfo")]
@@ -132,6 +169,11 @@ namespace Firebase.Auth
 		[Export ("currentUser", ArgumentSemantic.Strong)]
 		User CurrentUser { get; }
 
+		// @property (nonatomic, copy, nullable) NSString *languageCode;
+		[NullAllowed]
+		[Export ("languageCode")]
+		string LanguageCode { get; set; }
+
 		[NullAllowed]
 		[Export ("APNSToken", ArgumentSemantic.Strong)]
 		NSData ApnsToken { get; set; }
@@ -184,6 +226,10 @@ namespace Firebase.Auth
 		[Export ("sendPasswordResetWithEmail:completion:")]
 		void SendPasswordReset (string email, [NullAllowed] SendPasswordResetHandler completion);
 
+		// - (void)sendPasswordResetWithEmail:(NSString *)email actionCodeSettings:(FIRActionCodeSettings*) actionCodeSettings completion:(nullable FIRSendPasswordResetCallback) completion;
+		[Export ("sendPasswordResetWithEmail:actionCodeSettings:completion:")]
+		void SendPasswordReset (string email, ActionCodeSettings actionCodeSettings, [NullAllowed] SendPasswordResetHandler completion);
+
 		// -(BOOL)signOut:(NSError * _Nullable * _Nullable)error;
 		[Export ("signOut:")]
 		bool SignOut ([NullAllowed] out NSError error);
@@ -203,6 +249,14 @@ namespace Firebase.Auth
 		// -(void)removeIDTokenDidChangeListener:(FIRIDTokenDidChangeListenerHandle _Nonnull)listenerHandle;
 		[Export ("removeIDTokenDidChangeListener:")]
 		void RemoveIdTokenDidChangeListener (NSObject listenerHandler);
+
+		// - (void) useAppLanguage;
+		[Export ("useAppLanguage")]
+		void UseAppLanguage ();
+
+		// - (BOOL)canHandleURL:(nonnull NSURL *)URL;
+		[Export ("canHandleURL:")]
+		void CanHandleUrl (NSUrl url);
 
 		// -(void)setAPNSToken:(NSData * _Nonnull)token type:(FIRAuthAPNSTokenType)type;
 		[Export ("setAPNSToken:type:")]
@@ -235,6 +289,27 @@ namespace Firebase.Auth
 		// @property (readonly, nonatomic) FIRAdditionalUserInfo * _Nullable additionalUserInfo;
 		[NullAllowed, Export ("additionalUserInfo")]
 		AdditionalUserInfo AdditionalUserInfo { get; }
+	}
+
+	interface IAuthUIDelegate
+	{
+	}
+
+	// @protocol FIRAuthUIDelegate <NSObject>
+	[Model]
+	[Protocol]
+	[BaseType (typeof (NSObject), Name = "FIRAuthUIDelegate")]
+	interface AuthUIDelegate
+	{
+		// @required -(void)presentViewController:(UIViewController * _Nonnull)viewControllerToPresent animated:(BOOL)flag completion:(void (^ _Nullable)(void))completion;
+		[Abstract]
+		[Export ("presentViewController:animated:completion:")]
+		void PresentViewController (UIViewController viewControllerToPresent, bool flag, [NullAllowed] Action completion);
+
+		// @required -(void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^ _Nullable)(void))completion;
+		[Abstract]
+		[Export ("dismissViewControllerAnimated:completion:")]
+		void DismissViewControllerAnimated (bool flag, [NullAllowed] Action completion);
 	}
 
 	// @interface FIREmailAuthProvider : NSObject
@@ -348,8 +423,13 @@ namespace Firebase.Auth
 		PhoneAuthProvider From (Auth auth);
 
 		// -(void)verifyPhoneNumber:(NSString * _Nonnull)phoneNumber completion:(FIRVerificationResultCallback _Nullable)completion;
+		[Obsolete]
 		[Export ("verifyPhoneNumber:completion:")]
 		void VerifyPhoneNumber (string phoneNumber, [NullAllowed] VerificationResultHandler completion);
+
+		// - (void)verifyPhoneNumber:(NSString *)phoneNumber UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate completion:(nullable FIRVerificationResultCallback) completion;
+		[Export ("verifyPhoneNumber:UIDelegate:completion:")]
+		void VerifyPhoneNumber (string phoneNumber, [NullAllowed] IAuthUIDelegate uiDelegate , [NullAllowed] VerificationResultHandler completion);
 
 		// -(FIRPhoneAuthCredential * _Nonnull)credentialWithVerificationID:(NSString * _Nonnull)verificationID verificationCode:(NSString * _Nonnull)verificationCode;
 		[Export ("credentialWithVerificationID:verificationCode:")]
@@ -463,6 +543,10 @@ namespace Firebase.Auth
 		// -(void)sendEmailVerificationWithCompletion:(FIRSendEmailVerificationCallback _Nullable)completion;
 		[Export ("sendEmailVerificationWithCompletion:")]
 		void SendEmailVerification ([NullAllowed] SendEmailVerificationHandler completion);
+
+		// - (void)sendEmailVerificationWithActionCodeSettings:(FIRActionCodeSettings *)actionCodeSettings completion:(nullable FIRSendEmailVerificationCallback)completion;
+		[Export ("sendEmailVerificationWithActionCodeSettings:completion:")]
+		void SendEmailVerification (ActionCodeSettings actionCodeSettings, [NullAllowed] SendEmailVerificationHandler completion);
 
 		// -(void)deleteWithCompletion:(FIRUserProfileChangeCallback _Nullable)completion;
 		[Export ("deleteWithCompletion:")]

--- a/Firebase.Auth/source/Firebase.Auth/Firebase.Auth.targets
+++ b/Firebase.Auth/source/Firebase.Auth/Firebase.Auth.targets
@@ -3,12 +3,12 @@
 
 	<PropertyGroup>
 		<_FirebaseAuthAssemblyName>Firebase.Auth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseAuthAssemblyName>
-		<_FirebaseAuthItemsFolder>FAth-4.0.0</_FirebaseAuthItemsFolder>
+		<_FirebaseAuthItemsFolder>FAth-4.2.1</_FirebaseAuthItemsFolder>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(OutputType)'!='Library'">
 		<XamarinBuildDownload Include="$(_FirebaseAuthItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/38f7ad3e8d160574/FirebaseAuth-4.0.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/1b6eb7d4fc1a3e3f/FirebaseAuth-4.2.1.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseAuthItems"/>

--- a/Firebase.Auth/source/Firebase.Auth/FirebaseAuth.linkwith.cs
+++ b/Firebase.Auth/source/Firebase.Auth/FirebaseAuth.linkwith.cs
@@ -3,7 +3,7 @@ using ObjCRuntime;
 
 [assembly: LinkWith ("FirebaseAuth",
 		     LinkTarget.ArmV7 | LinkTarget.Arm64 | LinkTarget.Simulator | LinkTarget.Simulator64,
-		     Frameworks = "Security",
+                     Frameworks = "SafariServices Security",
 		     LinkerFlags = "-ObjC -lc++ -lsqlite3 -lz",
 		     ForceLoad = true,
 		     SmartLink = true)]

--- a/Firebase.Auth/source/Firebase.Auth/Structs.cs
+++ b/Firebase.Auth/source/Firebase.Auth/Structs.cs
@@ -23,7 +23,8 @@ namespace Firebase.Auth
 	{
 		Unknown = 0,
 		PasswordReset = 1,
-		VerifyEmail = 2
+		VerifyEmail = 2,
+		RecoverEmail = 3
 	}
 
 	[Native]
@@ -62,6 +63,12 @@ namespace Firebase.Auth
 		InvalidRecipientEmail = 17033,
 		[Obsolete ("Use InvalidRecipientEmail instead, this will be removed in future versions.")]
 		RecipientEmail = InvalidRecipientEmail,
+		MissingEmail = 17034,
+		MissingIosBundleID = 17036,
+		MissingAndroidPackageName = 17037,
+		UnauthorizedDomain = 17038,
+		InvalidContinueUri = 17039,
+		MissingContinueURI = 17040,
 		MissingPhoneNumber = 17041,
 		InvalidPhoneNumber = 17042,
 		MissingVerificationCode = 17043,
@@ -75,6 +82,11 @@ namespace Firebase.Auth
 		MissingAppToken = 17053,
 		NotificationNotForwarded = 17054,
 		AppNotVerified = 17055,
+		CaptchaCheckFailed = 17056,
+		WebContextAlreadyPresented = 17057,
+		WebContextCancelled = 17058,
+		AppVerificationUserInteractionFailure = 17059,
+		InvalidClientId = 17060,
 		KeychainError = 17995,
 		InternalError = 17999
 	}

--- a/Firebase.CloudMessaging/component/component.yaml
+++ b/Firebase.CloudMessaging/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.0
+version: 2.0.0.1
 name: Firebase Cloud Messaging for iOS
 id: firebaseioscloudmessaging
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.CloudMessaging, Version=2.0.0.0
+  - Xamarin.Firebase.iOS.CloudMessaging, Version=2.0.0.1
 samples:
 - name: Cloud Messaging Sample
   path: ../samples/CloudMessagingSample/CloudMessagingSample.sln

--- a/Firebase.CloudMessaging/component/component.yaml
+++ b/Firebase.CloudMessaging/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.1
+version: 2.0.4.0
 name: Firebase Cloud Messaging for iOS
 id: firebaseioscloudmessaging
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.CloudMessaging, Version=2.0.0.1
+  - Xamarin.Firebase.iOS.CloudMessaging, Version=2.0.4.0
 samples:
 - name: Cloud Messaging Sample
   path: ../samples/CloudMessagingSample/CloudMessagingSample.sln

--- a/Firebase.CloudMessaging/externals/Podfile
+++ b/Firebase.CloudMessaging/externals/Podfile
@@ -1,29 +1,29 @@
 =begin
 Last run FirebaseMessaging installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseInstanceID (2.0.0)
-- FirebaseMessaging (2.0.0)
-- GoogleToolboxForMac (2.1.1)
-- Protobuf (3.3.0)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseInstanceID (2.0.4)
+- FirebaseMessaging (2.0.4)
+- GoogleToolboxForMac (2.1.3)
+- Protobuf (3.4.0)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.CloudMessaging binding, you can find:
-- FirebaseMessaging (2.0.0)
+- FirebaseMessaging (2.0.4)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
-- Protobuf (3.3.0)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
+- Protobuf (3.4.0)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -32,5 +32,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseMessaging' do
-	pod 'Firebase/Messaging', '4.0.3'
+	pod 'Firebase/Messaging', '4.3.0'
 end

--- a/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
+++ b/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.CloudMessaging</id>
     <title>Firebase APIs Cloud Messaging iOS Library</title>
-    <version>2.0.0.0</version>
+    <version>2.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
+++ b/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
+++ b/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.CloudMessaging</id>
     <title>Firebase APIs Cloud Messaging iOS Library</title>
-    <version>2.0.0.1</version>
+    <version>2.0.4.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
+++ b/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.CloudMessaging/source/Firebase.CloudMessaging/Firebase.CloudMessaging.targets
+++ b/Firebase.CloudMessaging/source/Firebase.CloudMessaging/Firebase.CloudMessaging.targets
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_FirebaseCloudMessagingAssemblyName>Firebase.CloudMessaging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseCloudMessagingAssemblyName>
-		<_FirebaseCloudMessagingItemsFolder>FCldM-2.0.0</_FirebaseCloudMessagingItemsFolder>
+		<_FirebaseCloudMessagingItemsFolder>FCldM-2.0.4</_FirebaseCloudMessagingItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True'">
 		<XamarinBuildDownload Include="$(_FirebaseCloudMessagingItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/27dfa1033c3f49ba/FirebaseMessaging-2.0.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/d0ac220cfb625fd2/FirebaseMessaging-2.0.4.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseCloudMessagingItems" />

--- a/Firebase.Core/.gitignore
+++ b/Firebase.Core/.gitignore
@@ -1,3 +1,4 @@
-GTMSessionFetcher*
 GoogleToolboxForMac*
+nanopb*
+GTMSessionFetcher*
 Protobuf*

--- a/Firebase.Core/External-Dependency-Info
+++ b/Firebase.Core/External-Dependency-Info
@@ -220,6 +220,37 @@ whether by implication, estoppel or otherwise.
 ########################################
 
 ########################################
+# Nanopb - Protocol Buffers for Embedded Systems
+# https://github.com/nanopb/nanopb
+########################################
+
+
+Copyright (c) 2011 Petteri Aimonen <jpa at nanopb.mail.kapsi.fi>
+
+This software is provided 'as-is', without any express or 
+implied warranty. In no event will the authors be held liable 
+for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any 
+purpose, including commercial applications, and to alter it and 
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you 
+   must not claim that you wrote the original software. If you use 
+   this software in a product, an acknowledgment in the product 
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and 
+   must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source 
+   distribution.
+
+########################################
+# end - Nanopb - Protocol Buffers for Embedded Systems
+########################################
+
+########################################
 # Google Toolbox for Mac - Session Fetcher
 # https://github.com/google/gtm-session-fetcher
 ########################################
@@ -435,6 +466,7 @@ whether by implication, estoppel or otherwise.
 # Protobuf
 # https://github.com/google/protobuf
 ########################################
+
 
 Copyright 2014, Google Inc.  All rights reserved.
 

--- a/Firebase.Core/externals/Makefile
+++ b/Firebase.Core/externals/Makefile
@@ -3,7 +3,7 @@ XCODEBUILD=$(shell xcrun --sdk iphoneos --find xcodebuild)
 
 PROJECT_ROOT=./Pods
 PROJECT=$(PROJECT_ROOT)/Pods.xcodeproj
-TARGETS=GTMSessionFetcher GoogleToolboxForMac Protobuf
+TARGETS=GoogleToolboxForMac nanopb GTMSessionFetcher Protobuf
 
 all: Podfile.lock $(TARGETS)
 

--- a/Firebase.Core/externals/Podfile
+++ b/Firebase.Core/externals/Podfile
@@ -10,12 +10,13 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseCore' do
-	pod 'Firebase/Core', '4.0.3'
-	pod 'GoogleToolboxForMac/NSData+zlib', '2.1.1'
-	pod 'GoogleToolboxForMac/NSDictionary+URLArguments', '2.1.1'
-	pod 'GoogleToolboxForMac/Logger', '2.1.1'
-	pod 'GoogleToolboxForMac/StringEncoding', '2.1.1'
-	pod 'GoogleToolboxForMac/URLBuilder', '2.1.1'
-	pod 'GTMSessionFetcher/Full', '1.1.11'
-	pod 'Protobuf', '3.3.0'
+	pod 'Firebase/Core', '4.3.0'
+	pod 'GoogleToolboxForMac/NSData+zlib', '2.1.3'
+	pod 'GoogleToolboxForMac/NSDictionary+URLArguments', '2.1.3'
+	pod 'GoogleToolboxForMac/Logger', '2.1.3'
+	pod 'GoogleToolboxForMac/StringEncoding', '2.1.3'
+	pod 'GoogleToolboxForMac/URLBuilder', '2.1.3'
+	pod 'nanopb', '0.3.8'
+	pod 'GTMSessionFetcher/Full', '1.1.12'
+	pod 'Protobuf', '3.4.0'
 end

--- a/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
+++ b/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Core</id>
     <title>Firebase APIs Core iOS Library</title>
-    <version>4.0.3.0</version>
+    <version>4.0.8.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.Core/source/Firebase.Core/Firebase.Core.csproj
+++ b/Firebase.Core/source/Firebase.Core/Firebase.Core.csproj
@@ -58,5 +58,10 @@
       <Link>Protobuf</Link>
     </ObjcBindingNativeLibrary>
   </ItemGroup>
+  <ItemGroup>
+    <BundleResource Include="..\..\externals\nanopb">
+      <Link>nanopb</Link>
+    </BundleResource>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
 </Project>

--- a/Firebase.Core/source/Firebase.Core/Firebase.Core.csproj
+++ b/Firebase.Core/source/Firebase.Core/Firebase.Core.csproj
@@ -57,11 +57,9 @@
     <ObjcBindingNativeLibrary Include="..\..\externals\Protobuf">
       <Link>Protobuf</Link>
     </ObjcBindingNativeLibrary>
-  </ItemGroup>
-  <ItemGroup>
-    <BundleResource Include="..\..\externals\nanopb">
+    <ObjcBindingNativeLibrary Include="..\..\externals\nanopb">
       <Link>nanopb</Link>
-    </BundleResource>
+    </ObjcBindingNativeLibrary>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
 </Project>

--- a/Firebase.Core/source/Firebase.Core/Firebase.Core.targets
+++ b/Firebase.Core/source/Firebase.Core/Firebase.Core.targets
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_FirebaseCoreAssemblyName>Firebase.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseCoreAssemblyName>
-		<_FirebaseCoreItemsFolder>FCr-4.0.3</_FirebaseCoreItemsFolder>
+		<_FirebaseCoreItemsFolder>FCr-4.0.8</_FirebaseCoreItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseCoreItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/ee3b310e09a32f0b/FirebaseCore-4.0.3.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/a62ba73f1f65cd7b/FirebaseCore-4.0.8.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseCoreItemsFolder" />

--- a/Firebase.Core/source/Firebase.Core/FirebaseCore.linkwith.cs
+++ b/Firebase.Core/source/Firebase.Core/FirebaseCore.linkwith.cs
@@ -25,6 +25,11 @@ using ObjCRuntime;
 		     SmartLink = true,
 		     ForceLoad = true)]
 
+[assembly: LinkWith ("nanopb",
+		     LinkTarget.ArmV7 | LinkTarget.Arm64 | LinkTarget.Simulator | LinkTarget.Simulator64,
+		     SmartLink = true,
+		     ForceLoad = true)]
+
 [assembly: LinkWith ("GTMSessionFetcher",
 		     LinkTarget.ArmV7 | LinkTarget.Arm64 | LinkTarget.Simulator | LinkTarget.Simulator64,
 		     Frameworks = "Security",

--- a/Firebase.CrashReporting/component/component.yaml
+++ b/Firebase.CrashReporting/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.0
+version: 2.0.0.1
 name: Firebase Crash Reporting for iOS
 id: firebaseioscrashreporting
 publisher: Xamarin Inc.
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.CrashReporting, Version=2.0.0.0
+  - Xamarin.Firebase.iOS.CrashReporting, Version=2.0.0.1
 samples:
 - name: Crash Reporting Sample
   path: ../samples/CrashReportingSample/CrashReportingSample.sln

--- a/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
+++ b/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.CrashReporting</id>
     <title>Firebase APIs Crash Reporting iOS Library</title>
-    <version>2.0.0.0</version>
+    <version>2.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
+++ b/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
+++ b/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Database/.gitignore
+++ b/Firebase.Database/.gitignore
@@ -1,0 +1,1 @@
+leveldb-library*

--- a/Firebase.Database/External-Dependency-Info
+++ b/Firebase.Database/External-Dependency-Info
@@ -42,5 +42,5 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ########################################
-# end - Google Toolbox for Mac
+# end - LevelDB
 ########################################

--- a/Firebase.Database/External-Dependency-Info
+++ b/Firebase.Database/External-Dependency-Info
@@ -1,0 +1,46 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+Do not translate or localize
+
+Xamarin Components for Firebase APIs Database iOS Library incorporates third party 
+material from the projects listed below. The original copyright notice and 
+the license under which Microsoft received such third party material are set 
+forth below.  Microsoft reserves all other rights not expressly granted, 
+whether by implication, estoppel or otherwise.
+
+########################################
+# LevelDB
+# https://github.com/google/leveldb
+########################################
+
+
+Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+########################################
+# end - Google Toolbox for Mac
+########################################

--- a/Firebase.Database/component/component.yaml
+++ b/Firebase.Database/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.0.1
+version: 4.1.0.0
 name: Firebase Database for iOS
 id: firebaseiosdatabase
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Database, Version=4.0.0.1
+  - Xamarin.Firebase.iOS.Database, Version=4.1.0.0
 samples:
 - name: Database Sample
   path: ../samples/DatabaseSample/DatabaseSample.sln
@@ -44,3 +44,6 @@ samples:
   - //xNS:Import[contains (@Project, 'Firebase.InstanceID.targets')]
 local-nuget-repo: ../../tmp-nugets
 no_build: true
+additional-files:
+- source: ../External-Dependency-Info
+  destination: THIRD-PARTY-NOTICES

--- a/Firebase.Database/component/component.yaml
+++ b/Firebase.Database/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.0.0
+version: 4.0.0.1
 name: Firebase Database for iOS
 id: firebaseiosdatabase
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Database, Version=4.0.0.0
+  - Xamarin.Firebase.iOS.Database, Version=4.0.0.1
 samples:
 - name: Database Sample
   path: ../samples/DatabaseSample/DatabaseSample.sln

--- a/Firebase.Database/externals/Makefile
+++ b/Firebase.Database/externals/Makefile
@@ -1,12 +1,34 @@
-
 POD=pod
+XCODEBUILD=$(shell xcrun --sdk iphoneos --find xcodebuild)
 
-all: Podfile.lock
+PROJECT_ROOT=./Pods
+PROJECT=$(PROJECT_ROOT)/Pods.xcodeproj
+TARGETS=leveldb-library
 
-Podfile.lock :
+all: Podfile.lock $(TARGETS)
+
+Podfile.lock:
 	$(POD) install
 
+$(TARGETS):
+	$(MAKE) $@-iphoneos
+	$(MAKE) $@-iphonesimulator
+	lipo -create -output $@ $@-iphoneos $@-iphonesimulator
+
+%-iphoneos:
+	$(eval currentTarget=$(subst -iphoneos,,$@))
+	$(XCODEBUILD) -project $(PROJECT) -target $(currentTarget) -sdk iphoneos -arch armv7 -arch arm64 -configuration Release clean build
+	-mv ./build/Release-iphoneos/$(currentTarget)/lib$(currentTarget).a $@
+
+%-iphonesimulator:
+	$(eval currentTarget=$(subst -iphonesimulator,,$@))
+	$(XCODEBUILD) -project $(PROJECT) -target $(currentTarget) -sdk iphonesimulator -arch i386 -arch x86_64 -configuration Release clean build
+	-mv ./build/Release-iphonesimulator/$(currentTarget)/lib$(currentTarget).a $@
+
 clean:
-	rm -rf Podfile.lock Pods
+	@ rm -rf Podfile.lock Pods build
+	@ for target in $(TARGETS); do \
+        rm -f $$target*; \
+	done
 
 .PHONY: all clean

--- a/Firebase.Database/externals/Podfile
+++ b/Firebase.Database/externals/Podfile
@@ -1,31 +1,29 @@
 =begin
 Last run FirebaseDatabase installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseDatabase (4.0.0)
-- FirebaseInstanceID (2.0.0)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseDatabase (4.1.0)
+- FirebaseInstanceID (2.0.4)
+- GoogleToolboxForMac (2.1.3)
+- leveldb-library (1.18.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.Database binding, you can find:
-- FirebaseDatabase (4.0.0)
+- FirebaseDatabase (4.1.0)
+- leveldb-library (1.18.3)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -34,5 +32,6 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseDatabase' do
-	pod 'Firebase/Database', '4.0.3'
+	pod 'Firebase/Database', '4.3.0'
+	pod 'leveldb-library', '1.18.3'
 end

--- a/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
+++ b/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Database</id>
     <title>Firebase APIs Database iOS Library</title>
-    <version>4.0.0.0</version>
+    <version>4.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
+++ b/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Database</id>
     <title>Firebase APIs Database iOS Library</title>
-    <version>4.0.0.1</version>
+    <version>4.1.0.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -26,5 +26,6 @@
 
     <!-- Add targets file for external native reference download -->
     <file src="source/Firebase.Database/Firebase.Database.targets" target="build/Xamarin.Firebase.iOS.Database.targets" />
+    <file src="External-Dependency-Info" target="THIRD-PARTY-NOTICES" />
   </files>
 </package>

--- a/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
+++ b/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
+++ b/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Database/samples/DatabaseSample/DatabaseSample/DatabaseSample.csproj
+++ b/Firebase.Database/samples/DatabaseSample/DatabaseSample/DatabaseSample.csproj
@@ -28,6 +28,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>
@@ -56,6 +57,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Firebase.Database/source/Firebase.Database/ApiDefinition.cs
+++ b/Firebase.Database/source/Firebase.Database/ApiDefinition.cs
@@ -9,6 +9,7 @@ using CoreFoundation;
 namespace Firebase.Database
 {
 	// @interface FIRDatabase : NSObject
+	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRDatabase")]
 	interface Database
 	{
@@ -16,6 +17,16 @@ namespace Firebase.Database
 		[Static]
 		[Export ("database")]
 		Database DefaultInstance { get; }
+
+		// + (FIRDatabase *)databaseWithURL:(NSString *)url NS_SWIFT_NAME(database(url:));
+		[Static]
+		[Export ("databaseWithURL:")]
+		Database From (string url);
+
+		// + (FIRDatabase *)databaseForApp:(FIRApp *)app URL:(NSString*) url NS_SWIFT_NAME (database(app:url:));
+		[Static]
+		[Export ("databaseForApp:URL:")]
+		Database From (Firebase.Core.App app, string url);
 
 		// +(FIRDatabase * _Nonnull)databaseForApp:(FIRApp * _Nonnull)app;
 		[Static]

--- a/Firebase.Database/source/Firebase.Database/Firebase.Database.csproj
+++ b/Firebase.Database/source/Firebase.Database/Firebase.Database.csproj
@@ -62,5 +62,10 @@
   <ItemGroup>
     <None Include="Firebase.Database.targets" />
   </ItemGroup>
+  <ItemGroup>
+    <ObjcBindingNativeLibrary Include="..\..\externals\leveldb-library">
+      <Link>leveldb-library</Link>
+    </ObjcBindingNativeLibrary>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
 </Project>

--- a/Firebase.Database/source/Firebase.Database/Firebase.Database.targets
+++ b/Firebase.Database/source/Firebase.Database/Firebase.Database.targets
@@ -3,12 +3,12 @@
 
 	<PropertyGroup>
 		<_FirebaseDatabaseAssemblyName>Firebase.Database, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseDatabaseAssemblyName>
-		<_FirebaseDatabaseItemsFolder>FDtbs-4.0.0</_FirebaseDatabaseItemsFolder>
+		<_FirebaseDatabaseItemsFolder>FDtbs-4.1.0</_FirebaseDatabaseItemsFolder>
 	</PropertyGroup>
 
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseDatabaseItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/6037ebe07fd1f7c5/FirebaseDatabase-4.0.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/69f5052f31233669/FirebaseDatabase-4.1.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseDatabaseItems"/>

--- a/Firebase.Database/source/Firebase.Database/FirebaseDatabase.linkwith.cs
+++ b/Firebase.Database/source/Firebase.Database/FirebaseDatabase.linkwith.cs
@@ -7,3 +7,8 @@ using ObjCRuntime;
 		     LinkerFlags = "-ObjC -lc++ -licucore",
 		     ForceLoad = true,
 		     SmartLink = true)]
+
+[assembly: LinkWith ("leveldb-library",
+		     LinkTarget.ArmV7 | LinkTarget.Arm64 | LinkTarget.Simulator | LinkTarget.Simulator64,
+		     ForceLoad = true,
+		     SmartLink = true)]

--- a/Firebase.DynamicLinks/component/component.yaml
+++ b/Firebase.DynamicLinks/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.0
+version: 2.0.0.1
 name: Firebase Dynamic Links for iOS
 id: firebaseiosdynamiclinks
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.DynamicLinks, Version=2.0.0.0
+  - Xamarin.Firebase.iOS.DynamicLinks, Version=2.0.0.1
 samples:
 - name: Dynamic Links Sample
   path: ../samples/DynamicLinksSample/DynamicLinksSample.sln

--- a/Firebase.DynamicLinks/component/component.yaml
+++ b/Firebase.DynamicLinks/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.1
+version: 2.1.0.0
 name: Firebase Dynamic Links for iOS
 id: firebaseiosdynamiclinks
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.DynamicLinks, Version=2.0.0.1
+  - Xamarin.Firebase.iOS.DynamicLinks, Version=2.1.0.0
 samples:
 - name: Dynamic Links Sample
   path: ../samples/DynamicLinksSample/DynamicLinksSample.sln

--- a/Firebase.DynamicLinks/externals/Podfile
+++ b/Firebase.DynamicLinks/externals/Podfile
@@ -1,31 +1,27 @@
 =begin
 Last run FirebaseDynamicLinks installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseDynamicLinks (2.0.0)
-- FirebaseInstanceID (2.0.0)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseDynamicLinks (2.1.0)
+- FirebaseInstanceID (2.0.4)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.DynamicLinks binding, you can find:
-- FirebaseDynamicLinks (2.0.0)
+- FirebaseDynamicLinks (2.1.0)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
-- GoogleSymbolUtilities (1.1.2)
-- GoogleInterchangeUtilities (1.2.2)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -34,5 +30,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseDynamicLinks' do
-	pod 'Firebase/DynamicLinks', '4.0.3'
+	pod 'Firebase/DynamicLinks', '4.3.0'
 end

--- a/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
+++ b/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.DynamicLinks</id>
     <title>Firebase APIs Dynamic Links iOS Library</title>
-    <version>2.0.0.1</version>
+    <version>2.1.0.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
+++ b/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
+++ b/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.DynamicLinks</id>
     <title>Firebase APIs Dynamic Links iOS Library</title>
-    <version>2.0.0.0</version>
+    <version>2.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
+++ b/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.DynamicLinks/source/Firebase.DynamicLinks/ApiDefinition.cs
+++ b/Firebase.DynamicLinks/source/Firebase.DynamicLinks/ApiDefinition.cs
@@ -303,6 +303,9 @@ namespace Firebase.DynamicLinks
 	// typedef void (^FIRDynamicLinkUniversalLinkHandler)(FIRDynamicLink * _Nullable dynamicLink, NSError* _Nullable error);
 	delegate void DynamicLinkUniversalLinkHandler ([NullAllowed] DynamicLink dynamicLink, [NullAllowed] NSError error);
 
+	// void (^_Nullable)(NSString *diagnosticOutput, BOOL hasErrors)
+	delegate void DynamicLinkDiagnosticOutputHandler (string diagnosticOutput, bool hasErrors);
+
 	// @interface FIRDynamicLinks : NSObject
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "FIRDynamicLinks")]
@@ -339,6 +342,11 @@ namespace Firebase.DynamicLinks
 		// -(BOOL)matchesShortLinkFormat:(NSURL * _Nonnull)url;
 		[Export ("matchesShortLinkFormat:")]
 		bool MatchesShortLinkFormat (NSUrl url);
+
+		// + (void)performDiagnosticsWithCompletion:(void (^_Nullable)(NSString *diagnosticOutput, BOOL hasErrors))completionHandler;
+		[Static]
+		[Export ("performDiagnosticsWithCompletion:")]
+		void PerformDiagnostics ([NullAllowed] DynamicLinkDiagnosticOutputHandler completion);
 	}
 }
 

--- a/Firebase.DynamicLinks/source/Firebase.DynamicLinks/Firebase.DynamicLinks.targets
+++ b/Firebase.DynamicLinks/source/Firebase.DynamicLinks/Firebase.DynamicLinks.targets
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_FirebaseDynamicLinksAssemblyName>Firebase.DynamicLinks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseDynamicLinksAssemblyName>
-		<_FirebaseDynamicLinksItemsFolder>FDynmcL-2.0.0</_FirebaseDynamicLinksItemsFolder>
+		<_FirebaseDynamicLinksItemsFolder>FDynmcL-2.1.0</_FirebaseDynamicLinksItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseDynamicLinksItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/a9edf76eb06448ec/FirebaseDynamicLinks-2.0.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/57e72b1920be2b5b/FirebaseDynamicLinks-2.1.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseDynamicLinksItems" />

--- a/Firebase.InstanceID/externals/Podfile
+++ b/Firebase.InstanceID/externals/Podfile
@@ -10,5 +10,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseInstanceID' do
-	pod 'FirebaseInstanceID', '2.0.0'
+	pod 'FirebaseInstanceID', '2.0.4'
 end

--- a/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
+++ b/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.InstanceID</id>
     <title>Firebase APIs Instance ID iOS Library</title>
-    <version>2.0.0.0</version>
+    <version>2.0.4.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.InstanceID/source/Firebase.InstanceID/Firebase.InstanceID.targets
+++ b/Firebase.InstanceID/source/Firebase.InstanceID/Firebase.InstanceID.targets
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseInstanceIDItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/9fe91bfb8772be4b/FirebaseInstanceID-2.0.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/921adf5f4d0ba359/FirebaseInstanceID-2.0.4.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseInstanceIDItems" />

--- a/Firebase.Invites/component/component.yaml
+++ b/Firebase.Invites/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.1
+version: 2.0.1.0
 name: Firebase Invites for iOS
 id: firebaseiosinvites
 publisher: Xamarin Inc.
@@ -21,7 +21,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Invites, Version=2.0.0.1
+  - Xamarin.Firebase.iOS.Invites, Version=2.0.1.0
 samples:
 - name: Invites Sample
   path: ../samples/InvitesSample/InvitesSample.sln

--- a/Firebase.Invites/component/component.yaml
+++ b/Firebase.Invites/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.0
+version: 2.0.0.1
 name: Firebase Invites for iOS
 id: firebaseiosinvites
 publisher: Xamarin Inc.
@@ -21,7 +21,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Invites, Version=2.0.0.0
+  - Xamarin.Firebase.iOS.Invites, Version=2.0.0.1
 samples:
 - name: Invites Sample
   path: ../samples/InvitesSample/InvitesSample.sln

--- a/Firebase.Invites/externals/Podfile
+++ b/Firebase.Invites/externals/Podfile
@@ -1,48 +1,44 @@
 =begin
 Last run FirebaseInvites installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseDynamicLinks (2.0.0)
-- FirebaseInstanceID (2.0.0)
-- FirebaseInvites (2.0.0)
-- GTMOAuth2 (1.1.4)
-- GTMSessionFetcher (1.1.11)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseDynamicLinks (2.1.0)
+- FirebaseInstanceID (2.0.4)
+- FirebaseInvites (2.0.1)
+- GTMOAuth2 (1.1.5)
+- GTMSessionFetcher (1.1.12)
 - GoogleAPIClientForREST (1.3.1)
-- GoogleSignIn (4.0.2)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)
-- GoogleToolboxForMac (2.1.1)
+- GoogleSignIn (4.1.0)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.Invites binding, you can find:
-- FirebaseInvites (2.0.0)
-- GoogleAPIClientForREST (1.3.0)
+- FirebaseInvites (2.0.1)
+- GoogleAPIClientForREST (1.3.1)
 
 In .targets file, located in Google.SignIn binding, you can find:
-- GoogleSignIn (4.0.2)
-- GTMOAuth2 (1.1.4)
+- GoogleSignIn (4.1.0)
+- GTMOAuth2 (1.1.5)
 
 In .targets file, located in Google.Core binding, you can find:
-- Google (3.0.3)
+- Google (3.1.0)
 
 In .targets file, located in Firebase.DynamicLinks binding, you can find:
--  FirebaseDynamicLinks (2.0.0)
+-  FirebaseDynamicLinks (2.1.0)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
-- GTMSessionFetcher (1.1.11)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)	
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
+- GTMSessionFetcher (1.1.12)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -51,5 +47,6 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseInvites' do
-	pod 'Firebase/Invites', '4.0.3'
+	pod 'Firebase/Invites', '4.3.0'
+	pod 'GoogleAPIClientForREST', '1.3.1'
 end

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Invites</id>
     <title>Firebase APIs Invites iOS Library</title>
-    <version>2.0.0.1</version>
+    <version>2.0.1.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
+        <dependency id="Xamarin.Google.iOS.SignIn" version="4.1.0.0" />
         <dependency id="Xamarin.Google.iOS.Core" version="3.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -20,7 +20,7 @@
         <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.0.0.1" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
-        <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.0.0.1" />
+        <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -18,7 +18,7 @@
         <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
         <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.0.0.1" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Invites</id>
     <title>Firebase APIs Invites iOS Library</title>
-    <version>2.0.0.0</version>
+    <version>2.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,11 +15,11 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.2" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.7" />
-        <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.0.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Firebase.iOS.DynamicLinks" version="2.0.0.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.Invites/samples/InvitesSample/InvitesSample/AppDelegate.cs
+++ b/Firebase.Invites/samples/InvitesSample/InvitesSample/AppDelegate.cs
@@ -3,6 +3,7 @@ using UIKit;
 using Firebase.Core;
 using Firebase.Invites;
 using Google.SignIn;
+using Firebase.DynamicLinks;
 
 namespace InvitesSample
 {
@@ -49,7 +50,7 @@ namespace InvitesSample
 			}
 
 			// Handle Sign In
-			return SignIn.SharedInstance.HandleUrl (url, sourceApplication, annotation);
+			return SignIn.SharedInstance.HandleUrl (url, sourceApplication ?? "", annotation);
 		}
 
 		public static void ShowMessage (string title, string message, UIViewController fromViewController)

--- a/Firebase.Invites/source/Firebase.Invites/Firebase.Invites.targets
+++ b/Firebase.Invites/source/Firebase.Invites/Firebase.Invites.targets
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <_FirebaseInvitesAssemblyName>Firebase.Invites, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseInvitesAssemblyName>
-        <_FirebaseInvitesItemsFolder>FInvts-2.0.0</_FirebaseInvitesItemsFolder>
+        <_FirebaseInvitesItemsFolder>FInvts-2.0.1</_FirebaseInvitesItemsFolder>
     </PropertyGroup>
     <ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
         <XamarinBuildDownload Include="$(_FirebaseInvitesItemsFolder)">
-            <Url>https://dl.google.com/dl/cpdc/eec13b11fe5b2c91/FirebaseInvites-2.0.0.tar.gz</Url>
+            <Url>https://dl.google.com/dl/cpdc/edb1334d7e76e530/FirebaseInvites-2.0.1.tar.gz</Url>
             <Kind>Tgz</Kind>
         </XamarinBuildDownload>
         <XamarinBuildRestoreResources Include="_FirebaseInvitesItems" />

--- a/Firebase.RemoteConfig/component/component.yaml
+++ b/Firebase.RemoteConfig/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.1.1
+version: 2.0.3.0
 name: Firebase Remote Config for iOS
 id: firebaseiosremoteconfig
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.RemoteConfig, Version=2.0.1.1
+  - Xamarin.Firebase.iOS.RemoteConfig, Version=2.0.3.0
 samples:
 - name: Remote Config Sample
   path: ../samples/RemoteConfigSample/RemoteConfigSample.sln

--- a/Firebase.RemoteConfig/component/component.yaml
+++ b/Firebase.RemoteConfig/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.1.0
+version: 2.0.1.1
 name: Firebase Remote Config for iOS
 id: firebaseiosremoteconfig
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.RemoteConfig, Version=2.0.1.0
+  - Xamarin.Firebase.iOS.RemoteConfig, Version=2.0.1.1
 samples:
 - name: Remote Config Sample
   path: ../samples/RemoteConfigSample/RemoteConfigSample.sln

--- a/Firebase.RemoteConfig/externals/Podfile
+++ b/Firebase.RemoteConfig/externals/Podfile
@@ -1,28 +1,27 @@
 =begin
 Last run FirebaseRemoteConfig installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseInstanceID (2.0.0)
-- FirebaseRemoteConfig (2.0.1)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseInstanceID (2.0.4)
+- FirebaseRemoteConfig (2.0.3)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.RemoteConfig binding, you can find:
-- FirebaseRemoteConfig (2.0.1)
+- FirebaseRemoteConfig (2.0.3)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -31,5 +30,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseRemoteConfig' do
-	pod 'Firebase/RemoteConfig', '4.0.3'
+	pod 'Firebase/RemoteConfig', '4.3.0'
 end

--- a/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
+++ b/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.RemoteConfig</id>
     <title>Firebase APIs Remote Config iOS Library</title>
-    <version>2.0.1.1</version>
+    <version>2.0.3.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
+++ b/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.RemoteConfig</id>
     <title>Firebase APIs Remote Config iOS Library</title>
-    <version>2.0.1.0</version>
+    <version>2.0.1.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
+++ b/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
+++ b/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.RemoteConfig/source/Firebase.RemoteConfig/Firebase.RemoteConfig.targets
+++ b/Firebase.RemoteConfig/source/Firebase.RemoteConfig/Firebase.RemoteConfig.targets
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_FirebaseRemoteConfigAssemblyName>Firebase.RemoteConfig, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseRemoteConfigAssemblyName>
-		<_FirebaseRemoteConfigItemsFolder>FRmtC-2.0.1</_FirebaseRemoteConfigItemsFolder>
+		<_FirebaseRemoteConfigItemsFolder>FRmtC-2.0.3</_FirebaseRemoteConfigItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True'">
 		<XamarinBuildDownload Include="$(_FirebaseRemoteConfigItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/976f014c63cbfd58/FirebaseRemoteConfig-2.0.1.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/08dd81caf98597f4/FirebaseRemoteConfig-2.0.3.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseRemoteConfigItems" />

--- a/Firebase.Storage/component/component.yaml
+++ b/Firebase.Storage/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.1
+version: 2.0.2.0
 name: Firebase Storage for iOS
 id: firebaseiosstorage
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Storage, Version=2.0.0.1
+  - Xamarin.Firebase.iOS.Storage, Version=2.0.2.0
 samples:
 - name: Storage Sample
   path: ../samples/StorageSample/StorageSample.sln

--- a/Firebase.Storage/component/component.yaml
+++ b/Firebase.Storage/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.0
+version: 2.0.0.1
 name: Firebase Storage for iOS
 id: firebaseiosstorage
 publisher: Xamarin Inc.
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Storage, Version=2.0.0.0
+  - Xamarin.Firebase.iOS.Storage, Version=2.0.0.1
 samples:
 - name: Storage Sample
   path: ../samples/StorageSample/StorageSample.sln

--- a/Firebase.Storage/externals/Podfile
+++ b/Firebase.Storage/externals/Podfile
@@ -1,29 +1,29 @@
 =begin
 Last run FirebaseStorage installed:
-- FirebaseAnalytics (4.0.2)
-- FirebaseCore (4.0.3)
-- FirebaseInstanceID (2.0.0)
-- FirebaseStorage (2.0.0)
-- GTMSessionFetcher (1.1.9)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseInstanceID (2.0.4)
+- FirebaseStorage (2.0.2)
+- GTMSessionFetcher (1.1.12)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Firebase.Storage binding, you can find:
-- FirebaseStorage (2.0.0)
+- FirebaseStorage (2.0.2)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (4.0.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (4.0.3)
-- GoogleToolboxForMac (2.1.1)
-- GTMSessionFetcher (1.1.9)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
+- GTMSessionFetcher (1.1.12)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (2.0.0)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -32,5 +32,5 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseStorage' do
-	pod 'Firebase/Storage', '4.0.3'
+	pod 'Firebase/Storage', '4.3.0'
 end

--- a/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
+++ b/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Storage</id>
     <title>Firebase APIs Storage iOS Library</title>
-    <version>2.0.0.1</version>
+    <version>2.0.2.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
+++ b/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Storage</id>
     <title>Firebase APIs Storage iOS Library</title>
-    <version>2.0.0.0</version>
+    <version>2.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
+++ b/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
+++ b/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Storage/samples/StorageSample/StorageSample/StorageSample.csproj
+++ b/Firebase.Storage/samples/StorageSample/StorageSample/StorageSample.csproj
@@ -22,13 +22,14 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <MtouchFastDev>false</MtouchFastDev>
-    <MtouchProfiling>true</MtouchProfiling>
+    <MtouchProfiling>false</MtouchProfiling>
     <IOSDebuggerPort>42820</IOSDebuggerPort>
     <MtouchLink>None</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>
@@ -57,6 +58,7 @@
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <MtouchTlsProvider>Default</MtouchTlsProvider>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Firebase.Storage/source/Firebase.Storage/Firebase.Storage.targets
+++ b/Firebase.Storage/source/Firebase.Storage/Firebase.Storage.targets
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_FirebaseStorageAssemblyName>Firebase.Storage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseStorageAssemblyName>
-		<_FirebaseStorageItemsFolder>FStrg-2.0.0</_FirebaseStorageItemsFolder>
+		<_FirebaseStorageItemsFolder>FStrg-2.0.2</_FirebaseStorageItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseStorageItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/88f50faaf6f5f2a6/FirebaseStorage-2.0.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/2c34d0d4ad5fc168/FirebaseStorage-2.0.2.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_FirebaseStorageItems" />

--- a/Google.Core/externals/Podfile
+++ b/Google.Core/externals/Podfile
@@ -1,37 +1,34 @@
 =begin
 Last run Google/Core installed:
-- FirebaseAnalytics (3.2.1)
-- FirebaseInstanceID (1.0.7)
-- Google (3.0.3)
-- GoogleInterchangeUtilities (1.2.1)
-- GoogleSymbolUtilities (1.1.1)
-- GoogleUtilities (1.3.1)
+- FirebaseAnalytics (3.9.0)
+- FirebaseCore (3.6.0)
+- FirebaseInstanceID (1.0.10)
+- Google (3.1.0)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Google.Core binding, you can find:
-- Google (3.0.3)
-
-In .targets file, located in Google.MobileAds binding, you can find:
-- Google-Mobile-Ads-SDK (7.8.1)
+- Google (3.1.0)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (3.2.1)
-- GoogleInterchangeUtilities (1.2.1)
-- GoogleSymbolUtilities (1.1.1)
-- GoogleUtilities (1.3.1)
+- FirebaseAnalytics (3.9.0)
+
+In .targets file, located in Firebase.Core binding, you can find:
+- FirebaseCore (3.6.0)
+- GoogleToolboxForMac (2.1.3)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (1.0.7)
+- FirebaseInstanceID (1.0.10)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-platform :ios, '7.1'
+platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'GoogleCore' do
-	pod 'Google/Core', '3.0.3'
+	pod 'Google/Core', '3.1.0'
 end

--- a/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
+++ b/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.Core</id>
     <title>Google APIs Core iOS Library</title>
-    <version>3.0.3.8</version>
+    <version>3.1.0.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
+++ b/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
+++ b/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
+++ b/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.Core</id>
     <title>Google APIs Core iOS Library</title>
-    <version>3.0.3.7</version>
+    <version>3.0.3.8</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Google.Core/source/Google.Core/Google.Core.targets
+++ b/Google.Core/source/Google.Core/Google.Core.targets
@@ -2,11 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleCoreAssemblyName>Google.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleCoreAssemblyName>
-		<_GoogleCoreItemsFolder>GCr-3.0.3</_GoogleCoreItemsFolder>
+		<_GoogleCoreItemsFolder>GCr-3.1.0</_GoogleCoreItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_GoogleCoreItemsFolder)">
-			<Url>https://www.gstatic.com/cpdc/8f4d85570fdd4ab9-Google-3.0.3.tar.gz</Url>
+			<Url>https://www.gstatic.com/cpdc/4f036175e1463726-Google-3.1.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<XamarinBuildRestoreResources Include="_GoogleCoreItems" />

--- a/Google.InstanceID/component/component.yaml
+++ b/Google.InstanceID/component/component.yaml
@@ -1,4 +1,4 @@
-version: 1.2.1.9
+version: 1.2.1.10
 name: Google Instance ID for iOS
 id: googleiosinstanceid
 publisher: Xamarin Inc.
@@ -19,7 +19,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.InstanceID, Version=1.2.1.9
+  - Xamarin.Google.iOS.InstanceID, Version=1.2.1.10
 samples:
 - name: InstanceID Sample
   path: ../samples/InstanceIDSample/InstanceIDSample.sln

--- a/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
+++ b/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.InstanceID</id>
     <title>Google APIs Instance ID iOS Library</title>
-    <version>1.2.1.9</version>
+    <version>1.2.1.10</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,9 +15,9 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.7" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
+++ b/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />

--- a/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
+++ b/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
+++ b/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
@@ -18,7 +18,7 @@
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Google.MobileAds/component/component.yaml
+++ b/Google.MobileAds/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.21.0.0
+version: 7.24.1.0
 name: Google Mobile Ads for iOS
 id: googleiosmobileads
 publisher: Xamarin Inc
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.MobileAds, Version=7.21.0.0
+  - Xamarin.Google.iOS.MobileAds, Version=7.24.1.0
 samples:
 - name: Google Mobile Ads AdMob Sample
   path: ../samples/MobileAdsExample/MobileAdsExample.sln

--- a/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
+++ b/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.MobileAds</id>
     <title>Google APIs Mobile Ads iOS Library</title>
-    <version>7.21.0.0</version>
+    <version>7.24.1.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
+++ b/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
@@ -202,6 +202,15 @@ namespace Google.MobileAds
 		void IsSDKVersionAtLeast (nint major, nint minor, nint patch);
 	}
 
+	// @interface GADMultipleAdsAdLoaderOptions : GADAdLoaderOptions
+	[BaseType(typeof(AdLoaderOptions), Name = "GADMultipleAdsAdLoaderOptions")]
+	interface MultipleAdsAdLoaderOptions
+	{
+		// @property(nonatomic) NSInteger numberOfAds;
+		[Export("numberOfAds")]
+		nint NumberOfAds { get; set; }
+	}
+
 	interface IAdNetworkExtras
 	{
 
@@ -303,7 +312,7 @@ namespace Google.MobileAds
 	[Model]
 	[Protocol]
 	[BaseType (typeof (NSObject), Name = "GADBannerViewDelegate")]
-	interface BannerViewDelegate : AdDelegate
+	interface BannerViewDelegate
 	{
 
 		[EventArgs ("BannerViewE")]
@@ -409,7 +418,7 @@ namespace Google.MobileAds
 	[Model]
 	[Protocol]
 	[BaseType (typeof (NSObject), Name = "GADInterstitialDelegate")]
-	interface InterstitialDelegate : AdDelegate
+	interface InterstitialDelegate
 	{
 
 		[EventArgs ("InterstitialE")]
@@ -831,6 +840,10 @@ namespace Google.MobileAds
 		// - (BOOL)customControlsEnabled;
 		[Export ("customControlsEnabled")]
 		bool IsCustomControlsEnabled { get; }
+
+		// - (BOOL)clickToExpandEnabled;
+		[Export("clickToExpandEnabled")]
+		bool IsClickToExpandEnabled { get; }
 	}
 
 	interface IVideoControllerDelegate
@@ -885,6 +898,10 @@ namespace Google.MobileAds
 		// @property(nonatomic, assign) BOOL customControlsRequested;
 		[Export ("customControlsRequested", ArgumentSemantic.Assign)]
 		bool CustomControlsRequested { get; set; }
+
+		//@property(nonatomic, assign) BOOL clickToExpandRequested;
+		[Export("clickToExpandRequested", ArgumentSemantic.Assign)]
+		bool ClickToExpandRequested { get; set; }
 	}
 
 	#endregion
@@ -900,19 +917,10 @@ namespace Google.MobileAds
 		NativeAd NativeAd { get; set; }
 	}
 
-	interface IAdDelegate
+	// @interface GADAdLoaderOptions : NSObject
+	[BaseType(typeof(NSObject), Name = "GADAdLoaderOptions")]
+	interface AdLoaderOptions
 	{
-	}
-
-	// @protocol GADAdDelegate<NSObject>
-	[Model]
-	[Protocol]
-	[BaseType (typeof (NSObject), Name = "GADAdDelegate")]
-	interface AdDelegate
-	{
-		// @optional - (BOOL)ad:(id)ad shouldChangeAudioSessionToCategory:(NSString *)audioSessionCategory;
-		[Export ("ad:shouldChangeAudioSessionToCategory:")]
-		bool ShouldChangeAudioSessionToCategory (NSObject ad, string audioSessionCategory);
 	}
 
 	// @interface GADAdLoader : NSObject
@@ -928,9 +936,13 @@ namespace Google.MobileAds
 		[Export ("adUnitID")]
 		string AdUnitID { get; }
 
+		// @property(nonatomic, getter=isLoading, readonly) BOOL loading;
+		[Export("isLoading")]
+		bool IsLoading { get; }
+
 		// -(instancetype)initWithAdUnitID:(NSString *)adUnitID rootViewController:(UIViewController *)rootViewController adTypes:(NSArray *)adTypes options:(NSArray *)options;
 		[Export ("initWithAdUnitID:rootViewController:adTypes:options:")]
-		IntPtr Constructor (string adUnitID, [NullAllowed] UIViewController rootViewController, [NullAllowed] NSObject [] adTypes, [NullAllowed] AdLoaderOptions [] options);
+		IntPtr Constructor (string adUnitID, [NullAllowed] UIViewController rootViewController, NSString [] adTypes, [NullAllowed] AdLoaderOptions [] options);
 
 		// -(void)loadRequest:(GADRequest *)request;
 		[Export ("loadRequest:")]
@@ -955,12 +967,6 @@ namespace Google.MobileAds
 		// extern NSString *const kGADAdLoaderAdTypeDFPBanner;
 		[Field ("kGADAdLoaderAdTypeDFPBanner", "__Internal")]
 		NSString DfpBanner { get; }
-	}
-
-	// @interface GADAdLoaderOptions : NSObject
-	[BaseType (typeof (NSObject), Name = "GADAdLoaderOptions")]
-	interface AdLoaderOptions
-	{
 	}
 
 	interface IAdLoaderDelegate
@@ -1373,6 +1379,7 @@ namespace Google.MobileAds
 		MediaView MediaView { get; }
 
 		// @property(atomic, copy) GADNativeAdCustomClickHandler customClickHandler;
+		[NullAllowed]
 		[Export ("customClickHandler", ArgumentSemantic.Copy)]
 		NativeAdCustomClickHandle CustomClickHandler { get; }
 

--- a/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
+++ b/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
@@ -2,12 +2,12 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleMobileAdsAssemblyName>Google.MobileAds, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleMobileAdsAssemblyName>
-		<_GoogleMobileAdsId>FAdM-7.21.0</_GoogleMobileAdsId>
+		<_GoogleMobileAdsId>FAdM-7.24.1</_GoogleMobileAdsId>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildRestoreResources Include="_GoogleMobileAdsItems" />
 		<XamarinBuildDownload Include="$(_GoogleMobileAdsId)">
-			<Url>https://dl.google.com/dl/cpdc/a6788e761b332cb0/Google-Mobile-Ads-SDK-7.21.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/08078151dcb54ba9/Google-Mobile-Ads-SDK-7.24.1.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 	</ItemGroup>

--- a/Google.MobileAds/source/Google.MobileAds/GoogleMobileAds.linkwith.cs
+++ b/Google.MobileAds/source/Google.MobileAds/GoogleMobileAds.linkwith.cs
@@ -2,9 +2,9 @@ using System;
 using ObjCRuntime;
 
 [assembly: LinkWith ("GoogleMobileAds",
-	LinkTarget.ArmV7 | LinkTarget.Arm64 | LinkTarget.Simulator | LinkTarget.Simulator64,
-	LinkerFlags = "-ObjC",
-	Frameworks = "AudioToolbox AVFoundation CoreGraphics CoreMedia CoreMotion CoreTelephony CoreVideo GLKit MediaPlayer MessageUI MobileCoreServices OpenGLES StoreKit SystemConfiguration",
-        WeakFrameworks = "AdSupport JavaScriptCore SafariServices WebKit",
-	ForceLoad = true,
-	SmartLink = true)]
+                     LinkTarget.ArmV7 | LinkTarget.Arm64 | LinkTarget.Simulator | LinkTarget.Simulator64,
+                     LinkerFlags = "-ObjC",
+                     Frameworks = "AudioToolbox AVFoundation CoreGraphics CoreMedia CoreMotion CoreTelephony CoreVideo GLKit MediaPlayer MessageUI MobileCoreServices OpenGLES Security StoreKit SystemConfiguration",
+                     WeakFrameworks = "AdSupport JavaScriptCore SafariServices WebKit",
+                     ForceLoad = true,
+                     SmartLink = true)]

--- a/Google.PlayGames/component/component.yaml
+++ b/Google.PlayGames/component/component.yaml
@@ -1,4 +1,4 @@
-version: 5.1.1.9
+version: 5.1.1.10
 name: Google Play Games for iOS
 id: googleiosplaygames
 publisher: Xamarin Inc.
@@ -20,7 +20,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.PlayGames, Version=5.1.1.9
+  - Xamarin.Google.iOS.PlayGames, Version=5.1.1.10
 samples:
 - name: Collect All The Stars
   path: ../samples/CollectAllTheStars/CollectAllTheStars.sln

--- a/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
+++ b/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />

--- a/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
+++ b/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
@@ -19,7 +19,7 @@
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>     
     </dependencies>
   </metadata>

--- a/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
+++ b/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
@@ -15,7 +15,7 @@
     <dependencies> 
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
+        <dependency id="Xamarin.Google.iOS.SignIn" version="4.1.0.0" />
         <dependency id="Xamarin.Google.iOS.Core" version="3.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />

--- a/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
+++ b/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
@@ -17,7 +17,7 @@
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>     

--- a/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
+++ b/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.PlayGames</id>
     <title>Google APIs Play Games iOS Library</title>
-    <version>5.1.1.9</version>
+    <version>5.1.1.10</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,10 +15,10 @@
     <dependencies> 
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.2" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.7" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Google.iOS.SignIn" version="4.0.2.3" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>     
     </dependencies>

--- a/Google.SignIn/component/component.yaml
+++ b/Google.SignIn/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.2.2
+version: 4.0.2.3
 name: Google Sign-In for iOS
 id: googleiossignin
 publisher: Xamarin Inc.
@@ -19,7 +19,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.SignIn, Version=4.0.2.2
+  - Xamarin.Google.iOS.SignIn, Version=4.0.2.3
 samples:
 - name: Sign-In Sample
   path: ../samples/SignInExample/SignInExample.sln

--- a/Google.SignIn/component/component.yaml
+++ b/Google.SignIn/component/component.yaml
@@ -1,4 +1,4 @@
-version: 4.0.2.3
+version: 4.1.0.0
 name: Google Sign-In for iOS
 id: googleiossignin
 publisher: Xamarin Inc.
@@ -19,7 +19,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.SignIn, Version=4.0.2.3
+  - Xamarin.Google.iOS.SignIn, Version=4.1.0.0
 samples:
 - name: Sign-In Sample
   path: ../samples/SignInExample/SignInExample.sln

--- a/Google.SignIn/externals/Podfile
+++ b/Google.SignIn/externals/Podfile
@@ -1,37 +1,31 @@
 =begin
 Last run GoogleSignIn installed:
-- FirebaseAnalytics (3.7.0)
-- FirebaseCore (3.5.2)
-- FirebaseInstanceID (1.0.9)
-- GTMOAuth2 (1.1.4)
-- GTMSessionFetcher (1.1.9)
-- GoogleAppUtilities (1.1.2)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSignIn (4.0.2)
-- GoogleSymbolUtilities (1.1.2)
-- GoogleToolboxForMac (2.1.1)
+- FirebaseAnalytics (4.0.4)
+- FirebaseCore (4.0.8)
+- FirebaseInstanceID (2.0.4)
+- GTMOAuth2 (1.1.5)
+- GTMSessionFetcher (1.1.12)
+- GoogleSignIn (4.1.0)
+- GoogleToolboxForMac (2.1.3)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In .targets file, located in Google.SignIn binding, you can find:
-- GoogleSignIn (4.0.2)
-- GTMOAuth2 (1.1.4)
-- GoogleAppUtilities (1.1.2)
+- GoogleSignIn (4.1.0)
+- GTMOAuth2 (1.1.5)
 
 In .targets file, located in Firebase.Analytics binding, you can find:
-- FirebaseAnalytics (3.7.0)
-- GoogleInterchangeUtilities (1.2.2)
-- GoogleSymbolUtilities (1.1.2)
+- FirebaseAnalytics (4.0.4)
 
 In .targets file, located in Firebase.Core binding, you can find:
-- FirebaseCore (3.5.2)
-- GoogleToolboxForMac (2.1.1)
-- GTMSessionFetcher (1.1.9)
+- FirebaseCore (4.0.8)
+- GoogleToolboxForMac (2.1.3)
+- GTMSessionFetcher (1.1.12)
 
 In .targets file, located in Firebase.InstanceID binding, you can find:
-- FirebaseInstanceID (1.0.9)
+- FirebaseInstanceID (2.0.4)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -40,7 +34,7 @@ platform :ios, '7.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'GoogleSignIn' do
-	pod 'GoogleSignIn',  '4.0.2'
-	pod 'Google/SignIn', '3.0.3'
-	pod 'Firebase/Core', '3.15.0'
+	pod 'GoogleSignIn',  '4.1.0'
+	pod 'Google/SignIn', '3.1.0'
+	pod 'GTMOAuth2', '1.1.5'
 end

--- a/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
+++ b/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.SignIn</id>
     <title>Google APIs Sign In iOS Library</title>
-    <version>4.0.2.3</version>
+    <version>4.1.0.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
+++ b/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.1.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />

--- a/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
+++ b/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>

--- a/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
+++ b/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.SignIn</id>
     <title>Google APIs Sign In iOS Library</title>
-    <version>4.0.2.2</version>
+    <version>4.0.2.3</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -15,9 +15,9 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
-        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.7" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
+++ b/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
@@ -18,7 +18,7 @@
         <dependency id="Xamarin.Google.iOS.Core" version="3.0.3.8" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Google.SignIn/source/Google.SignIn/Google.SignIn.targets
+++ b/Google.SignIn/source/Google.SignIn/Google.SignIn.targets
@@ -2,25 +2,19 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleSignInAssemblyName>Google.SignIn, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleSignInAssemblyName>
-		<_GoogleSignInItemsFolder>GSgnI-4.0.2</_GoogleSignInItemsFolder>
-<!--		<_GoogleAppUtilitiesItemsFolder>GAppU-1.1.2</_GoogleAppUtilitiesItemsFolder>-->
+		<_GoogleSignInItemsFolder>GSgnI-4.1.0</_GoogleSignInItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_GoogleSignInItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/8c8b391433bcab7b/GoogleSignIn-4.0.2.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/2191f86d4091df9c/GoogleSignIn-4.1.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
-		<!--<XamarinBuildDownload Include="$(_GoogleAppUtilitiesItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/09f214fda7470397/GoogleAppUtilities-1.1.2.tar.gz</Url>
-			<Kind>Tgz</Kind>
-		</XamarinBuildDownload>-->
 		<XamarinBuildRestoreResources Include="_GoogleSignInItems" />
 	</ItemGroup>
 	<Target Name="_GoogleSignInItems">
 
 		<PropertyGroup>
 			<_GoogleSignInSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleSignInItemsFolder)\</_GoogleSignInSDKBaseFolder>
-<!--			<_GoogleAppUtilitiesSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleAppUtilitiesItemsFolder)\Frameworks\frameworks\</_GoogleAppUtilitiesSDKBaseFolder>-->
 		</PropertyGroup>
 
 		<ItemGroup>
@@ -28,10 +22,6 @@
 				<LogicalName>GoogleSignIn</LogicalName>
 				<AssemblyName>$(_GoogleSignInAssemblyName)</AssemblyName>
 			</RestoreAssemblyResource>
-			<!--<RestoreAssemblyResource Include="$(_GoogleAppUtilitiesSDKBaseFolder)GoogleAppUtilities.framework\GoogleAppUtilities">
-				<LogicalName>GoogleAppUtilities</LogicalName>
-				<AssemblyName>$(_GoogleSignInAssemblyName)</AssemblyName>
-			</RestoreAssemblyResource>-->
 			<RestoreAssemblyResource Include="$(_GoogleSignInSDKBaseFolder)Resources\GoogleSignIn.bundle\Info.plist">
                 <LogicalName>__monotouch_content_GoogleSignIn.bundle_fInfo.plist</LogicalName>
                 <AssemblyName>$(_GoogleSignInAssemblyName)</AssemblyName>

--- a/Google.TagManager/component/component.yaml
+++ b/Google.TagManager/component/component.yaml
@@ -1,4 +1,4 @@
-version: 6.0.0.0
+version: 6.0.0.1
 name: Google Tag Manager for iOS
 id: googleiostagmanager
 publisher: Xamarin Inc.
@@ -19,7 +19,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.TagManager, Version=6.0.0.0
+  - Xamarin.Google.iOS.TagManager, Version=6.0.0.1
 samples:
 - name: Tag Manager Sample
   path: ../samples/TagManagerSample/TagManagerSample.sln

--- a/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
+++ b/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.TagManager</id>
     <title>Google APIs Tag Manager iOS Library</title>
-    <version>6.0.0.0</version>
+    <version>6.0.0.1</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -16,8 +16,8 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.Analytics" version="3.17.0.2" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
       </group>
     </dependencies>

--- a/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
+++ b/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
@@ -18,7 +18,7 @@
         <dependency id="Xamarin.Google.iOS.Analytics" version="3.17.0.2" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
+++ b/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
@@ -16,7 +16,7 @@
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.6" />
         <dependency id="Xamarin.Google.iOS.Analytics" version="3.17.0.2" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.2.1" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="4.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="2.0.4.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="4.0.8.0" />
       </group>


### PR DESCRIPTION
Updated components:
* Firebase.InstanceID updated to version 2.0.4
* Firebase.Core updated to version 4.0.8
* Firebase.Analytics update to version 4.0.4
* Firebase.AdMob updated to version 7.24.1.0
* Google.MobileAds updated to version 7.24.1.0
* Firebase.Auth updated to version 4.2.1.0
* Firebase.Database updated to version 4.1.0.0
* Firebase.DynamicLinks updated to version 2.1.0.0
* Firebase.CloudMessaging updated to version 2.0.4.0
* Firebase.RemoteConfig updated to version 2.0.3.0
* Firebase.Storage updated to version 2.0.2.0
* Google.Core updated to version 3.1.0.0
* Google.SignIn updated to version 4.1.0.0
* Firebase.Invites update to version 2.0.1.0

Bumped component version due update:
* Google.InstanceID bumped to version 1.2.1.10
* Google.TagManager bumped to version 6.0.0.1