### PR TITLE
Make CrashReporting.SharedInstace static

### DIFF
--- a/Firebase.CrashReporting/source/Firebase.CrashReporting/ApiDefinition.cs
+++ b/Firebase.CrashReporting/source/Firebase.CrashReporting/ApiDefinition.cs
@@ -13,6 +13,7 @@ namespace Firebase.CrashReporting
 	interface CrashReporting
 	{
 		// + (FIRCrash *)sharedInstance NS_SWIFT_NAME(sharedInstance());
+		[Static]
 		[Export ("sharedInstance")]
 		CrashReporting SharedInstance { get; }
 


### PR DESCRIPTION
As seen [here](https://firebase.google.com/docs/reference/ios/firebasecrash/api/reference/Classes/FIRCrash), `FIRCrash.sharedInstace` is a `class func`, so it should be represented as a static method.