### PR TITLE
Upgrade to GoogleCast SDK 3.5.6

### DIFF
--- a/Google.Cast/component/component.yaml
+++ b/Google.Cast/component/component.yaml
@@ -1,4 +1,4 @@
-version: 3.3.0.3
+version: 3.5.6.0
 name: Google Cast for iOS
 id: googleioscast
 publisher: Xamarin Inc.
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.Cast, Version=3.3.0.3
+  - Xamarin.Google.iOS.Cast, Version=3.5.6.0
 samples:
 - name: Cast Sample
   path: ../samples/CastSample/CastSample.sln

--- a/Google.Cast/externals/Podfile
+++ b/Google.Cast/externals/Podfile
@@ -4,5 +4,5 @@ platform :ios, '8.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'GoogleCast' do
-	pod 'google-cast-sdk', '3.3.0'
+	pod 'google-cast-sdk', '3.5.6'
 end

--- a/Google.Cast/nuget/Xamarin.Google.iOS.Cast.nuspec
+++ b/Google.Cast/nuget/Xamarin.Google.iOS.Cast.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.Cast</id>
     <title>Google APIs Cast iOS Library</title>
-    <version>3.3.0.3</version>
+    <version>3.5.6.0</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -3287,6 +3287,11 @@ namespace Google.Cast
 		[Export ("playPauseToggleButton", ArgumentSemantic.Weak)]
 		GCKUIButton PlayPauseToggleButton { get; set; }
 
+		// @property (readwrite, nonatomic, strong) GCKUIPlayPauseToggleController* playPauseToggleController;
+		[NullAllowed]
+		[Export ("playPauseToggleController")]
+		UIPlayPauseToggleController PlayPauseToggleController { get; set; }
+
 		// @property (readwrite, nonatomic, weak) UIButton * _Nullable stopButton;
 		[NullAllowed]
 		[Export ("stopButton", ArgumentSemantic.Weak)]
@@ -3454,6 +3459,18 @@ namespace Google.Cast
 		[NullAllowed]
 		[Export ("selectedTrackIDs", ArgumentSemantic.Copy)]
 		NSArray _SelectedTrackIds { get; set; }
+	}
+
+	[BaseType (typeof(UIViewController), Name = "GCKUIPlayPauseToggleController")]
+	interface UIPlayPauseToggleController
+	{
+		// @property(nonatomic, assign, readwrite) BOOL inputEnabled;
+		[Export ("inputEnabled")]
+		bool InputEnabled { get; set; }
+
+		// @property(nonatomic, assign, readwrite) GCKUIPlayPauseState playPauseState;
+		[Export ("playPauseState")]
+		PlayPauseState PlayPauseState { get; set; }
 	}
 
 	interface IUIMediaTrackSelectionViewControllerDelegate

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -2638,6 +2638,26 @@ namespace Google.Cast
 		// -(void)cancel;
 		[Export ("cancel")]
 		void Cancel ();
+
+		// -(void)complete
+		[Export ("complete")]
+		void Complete ();
+
+		// -(void)failWithError:
+		[Export ("failWithError")]
+		void Fail (Error error);
+
+		// -(void)abortWithReason
+		[Export ("abortWithReason")]
+		void Abort (RequestAbortReason reason);
+
+		// +(GCKRequest *) applicationRequest
+		[Export ("applicationRequest")]
+		Request ApplicationRequest ();
+
+		// -(BOOL)external
+		[Export ("external")]
+		bool External { get; }
 	}
 
 	interface IRequestDelegate

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -2644,11 +2644,11 @@ namespace Google.Cast
 		void Complete ();
 
 		// -(void)failWithError:
-		[Export ("failWithError")]
+		[Export ("failWithError:")]
 		void Fail (Error error);
 
 		// -(void)abortWithReason
-		[Export ("abortWithReason")]
+		[Export ("abortWithReason:")]
 		void Abort (RequestAbortReason reason);
 
 		// +(GCKRequest *) applicationRequest

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -215,9 +215,15 @@ namespace Google.Cast
 		[Export ("setSharedInstanceWithOptions:")]
 		void SetSharedInstance (CastOptions options);
 
+		// + (instancetype) sharedInstance
 		[Static]
 		[Export ("sharedInstance")]
 		CastContext SharedInstance { get; }
+
+		// +(BOOL) isSharedInstanceInitialized	
+		[Static]
+		[Export ("isSharedInstanceInitialized")]
+		bool IsSharedInstanceInitialized { get; }
 
 		// -(void)registerDeviceProvider:(GCKDeviceProvider * _Nonnull)deviceProvider;
 		[Export ("registerDeviceProvider:")]

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -918,6 +918,9 @@ namespace Google.Cast
 		[Export ("passiveScan")]
 		bool PassiveScan { get; set; }
 
+		[Export ("discoveryActive")]
+		bool DiscoveryActive { get; }
+
 		// @property (readonly, assign, nonatomic) NSUInteger deviceCount;
 		[Export ("deviceCount")]
 		nuint DeviceCount { get; }

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -3352,6 +3352,11 @@ namespace Google.Cast
 		[Export ("streamTimeRemainingLabel", ArgumentSemantic.Weak)]
 		UILabel StreamTimeRemainingLabel { get; set; }
 
+		// @property(nonatomic, strong, readwrite, GCK_NULLABLE) GCKUIStreamPositionController* streamPositionController;
+		[NullAllowed]
+		[Export ("streamPositionController")]
+		UIStreamPositionController StreamPositionController { get; set; }
+
 		// @property (assign, readwrite, nonatomic) BOOL displayTimeRemainingAsNegativeValue;
 		[Export ("displayTimeRemainingAsNegativeValue")]
 		bool DisplayTimeRemainingAsNegativeValue { get; set; }
@@ -3471,6 +3476,22 @@ namespace Google.Cast
 		// @property(nonatomic, assign, readwrite) GCKUIPlayPauseState playPauseState;
 		[Export ("playPauseState")]
 		PlayPauseState PlayPauseState { get; set; }
+	}
+
+	[BaseType(typeof(UIViewController), Name = "GCKUIStreamPositionController")]
+	interface UIStreamPositionController
+	{
+		// @property (nonatomic, assign, readwrite) NSTimeInterval streamPosition;
+		[Export ("streamPosition")]
+		double StreamPosition { get; set; }
+
+		// @property (nonatomic, assign, readwrite) NSTimeInterval streamDuration;
+		[Export ("streamDuration")]
+		double StreamDuration { get; set; }
+
+		// @property (nonatomic, assign, readwrite) BOOL inputEnabled;
+		[Export ("inputEnabled")]
+		bool InputEnabled { get; set; }
 	}
 
 	interface IUIMediaTrackSelectionViewControllerDelegate

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -295,6 +295,12 @@ namespace Google.Cast
 		[Export ("physicalVolumeButtonsWillControlDeviceVolume")]
 		bool PhysicalVolumeButtonsWillControlDeviceVolume { get; set; }
 
+		[Export ("disableDiscoveryAutostart")]
+		bool DisableDiscoveryAutostart { get; set; }
+
+		[Export ("suspendSessionsWhenBackgrounded")]
+		bool SuspendSessionsWhenBackgrounded { get; set; }
+
 		// @property (readwrite, copy, nonatomic) GCKLaunchOptions * _Nullable launchOptions;
 		[NullAllowed]
 		[Export ("launchOptions", ArgumentSemantic.Copy)]

--- a/Google.Cast/source/Google.Cast/Google.Cast.targets
+++ b/Google.Cast/source/Google.Cast/Google.Cast.targets
@@ -2,14 +2,14 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleCastAssemblyName>Google.Cast, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleCastAssemblyName>
-		<_GoogleCastItemsFolder>GCst-3.3.0</_GoogleCastItemsFolder>
+		<_GoogleCastItemsFolder>GCst-3.5.6</_GoogleCastItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_GoogleCastItemsFolder)">
-			<Url>https://redirector.gvt1.com/edgedl/chromecast/sdk/ios/GoogleCastSDK-Public-3.3.0-Release-ios.zip</Url>
+			<Url>https://developers.google.com/cast/downloads/GoogleCastSDK-Public-3.5.6-Release-ios.zip</Url>
 			<Kind>Zip</Kind>
 		</XamarinBuildDownload>
-		<NativeReference Include="$(XamarinBuildDownloadDir)$(_GoogleCastItemsFolder)\GoogleCastSDK-Public-3.3.0-Release\GoogleCast.framework">
+		<NativeReference Include="$(XamarinBuildDownloadDir)$(_GoogleCastItemsFolder)\GoogleCastSDK-Public-3.5.6-Release\GoogleCast.framework">
       		<IsCxx>False</IsCxx>
 			<LinkerFlags>-lc++</LinkerFlags>
 			<Frameworks>Accelerate AudioToolbox AVFoundation CFNetwork CoreBluetooth CoreGraphics CoreMedia CoreText Foundation MediaAccessibility MediaPlayer QuartzCore Security SystemConfiguration UIKit</Frameworks>

--- a/Google.Cast/source/Google.Cast/StructsAndEnums.cs
+++ b/Google.Cast/source/Google.Cast/StructsAndEnums.cs
@@ -344,4 +344,12 @@ namespace Google.Cast
 		Dv = 1,
 		Hdr = 2
 	}
+
+	[Native]
+	public enum PlayPauseState : long 
+	{
+		None = 0,
+		Play = 1,
+		Pause = 2
+	}
 }


### PR DESCRIPTION
The native SDK used in the Xamarin GoogleCast binding library contains some bugs that causes the app to crash when in the background in certain scenarios. I have a 100% repro on this by just switching off WiFi and setting the app to the background, after approx 3 minutes the app will be terminated. Google has addressed this issue in v3.4 (see [release notes](https://developers.google.com/cast/docs/release-notes#april-12-2017)). 

I thought I might as well use the latest and greatest native SDK. The changes here target [v3.5.6](https://developers.google.com/cast/docs/release-notes#october-12-2017)