### PR TITLE
[Fix] Firebase Crash Reporting v2.0.0.3

### DIFF
--- a/Firebase.CrashReporting/component/GettingStarted.md
+++ b/Firebase.CrashReporting/component/GettingStarted.md
@@ -50,9 +50,10 @@ Once you have your `GoogleService-Info.plist` file downloaded in your computer, 
 
 1. Add `GoogleService-Info.plist` file to your app project.
 2. Set `GoogleService-Info.plist` **build action** behaviour to `Bundle Resource` by Right clicking/Build Action.
-3. Add the following line of code somewhere in your app, typically in your AppDelegate's `FinishedLaunching` method (don't forget to import `Firebase.Core` namespace):
+3. Add the following line of code somewhere in your app, typically in your AppDelegate's `FinishedLaunching` method (don't forget to import `Firebase.Core` and `Firebase.CrashReporting` namespaces):
 
 ```csharp
+CrashReporting.Configure ();
 App.Configure ();
 ```
 

--- a/Firebase.CrashReporting/component/GettingStarted.md
+++ b/Firebase.CrashReporting/component/GettingStarted.md
@@ -142,6 +142,8 @@ var crash = new NSObject ();
 crash.PerformSelector (new Selector ("doesNotRecognizeSelector"), crash, 0);
 ```
 
+> _**Note:**_ _The string given to this method must be an escaped string due it will be passed to a C function and it expects an escaped string. For example, if you want to print a %, you must type %%. Passing an unescaped string may cause the termination of your app._
+
 ### Known issues
 
 * App doesn't compile when `Incremental builds` is enabled. (Bug [#43689][3])

--- a/Firebase.CrashReporting/component/component.yaml
+++ b/Firebase.CrashReporting/component/component.yaml
@@ -1,4 +1,4 @@
-version: 2.0.0.2
+version: 2.0.0.3
 name: Firebase Crash Reporting for iOS
 id: firebaseioscrashreporting
 publisher: Xamarin Inc.
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.CrashReporting, Version=2.0.0.2
+  - Xamarin.Firebase.iOS.CrashReporting, Version=2.0.0.3
 samples:
 - name: Crash Reporting Sample
   path: ../samples/CrashReportingSample/CrashReportingSample.sln

--- a/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
+++ b/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.CrashReporting</id>
     <title>Firebase APIs Crash Reporting iOS Library</title>
-    <version>2.0.0.2</version>
+    <version>2.0.0.3</version>
     <authors>Xamarin Inc.</authors>
     <owners>Xamarin Inc.</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/Firebase.CrashReporting/samples/CrashReportingSample/CrashReportingSample/AppDelegate.cs
+++ b/Firebase.CrashReporting/samples/CrashReportingSample/CrashReportingSample/AppDelegate.cs
@@ -1,6 +1,8 @@
 ﻿using Foundation;
 using UIKit;
+
 using Firebase.Core;
+using Firebase.CrashReporting;
 
 namespace CrashReportingSample
 {
@@ -20,6 +22,7 @@ namespace CrashReportingSample
 		{
 			// Override point for customization after application launch.
 			// If not required for your application you can safely delete this method
+			CrashReporting.Configure ();
 			App.Configure ();
 
 			return true;

--- a/Firebase.CrashReporting/source/Firebase.CrashReporting/Extension.cs
+++ b/Firebase.CrashReporting/source/Firebase.CrashReporting/Extension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 using Foundation;
 
@@ -11,12 +12,16 @@ namespace Firebase.CrashReporting
 		[DllImport ("__Internal", EntryPoint = "FIRCrashLogv")]
 		static extern void _FIRCrashLogv (IntPtr format, IntPtr varArgs);
 
+		static readonly Regex regex = new Regex (@"%\s*\d*\s*[*.#+-]*\s*\d*\s*[eEyYuUiIoOpPaAsSdDfFgGlLxXcC]?");
+
 		public static void Log (string message)
 		{
-			if (message == null)
-				throw new ArgumentNullException (nameof (message));
+			var fixedMessage = message ?? throw new ArgumentNullException (nameof (message));
 
-			var pMessage = NSString.CreateNative (message);
+			if (regex.IsMatch (fixedMessage))
+				fixedMessage = regex.Replace (fixedMessage, "%${0}");
+
+			var pMessage = NSString.CreateNative (fixedMessage);
 			_FIRCrashLogv (pMessage, IntPtr.Zero);
 			NSString.ReleaseNative (pMessage);
 		}

--- a/Firebase.CrashReporting/source/Firebase.CrashReporting/Extension.cs
+++ b/Firebase.CrashReporting/source/Firebase.CrashReporting/Extension.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 
 using Foundation;
 
@@ -12,16 +11,12 @@ namespace Firebase.CrashReporting
 		[DllImport ("__Internal", EntryPoint = "FIRCrashLogv")]
 		static extern void _FIRCrashLogv (IntPtr format, IntPtr varArgs);
 
-		static readonly Regex regex = new Regex (@"%\s*\d*\s*[*.#+-]*\s*\d*\s*[eEyYuUiIoOpPaAsSdDfFgGlLxXcC]?");
-
 		public static void Log (string message)
 		{
-			var fixedMessage = message ?? throw new ArgumentNullException (nameof (message));
+			if (message == null)
+				throw new ArgumentNullException (nameof (message));
 
-			if (regex.IsMatch (fixedMessage))
-				fixedMessage = regex.Replace (fixedMessage, "%${0}");
-
-			var pMessage = NSString.CreateNative (fixedMessage);
+			var pMessage = NSString.CreateNative (message);
 			_FIRCrashLogv (pMessage, IntPtr.Zero);
 			NSString.ReleaseNative (pMessage);
 		}

--- a/Firebase.CrashReporting/source/Firebase.CrashReporting/Extension.cs
+++ b/Firebase.CrashReporting/source/Firebase.CrashReporting/Extension.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+
 using Foundation;
 
 namespace Firebase.CrashReporting
@@ -18,6 +19,11 @@ namespace Firebase.CrashReporting
 			var pMessage = NSString.CreateNative (message);
 			_FIRCrashLogv (pMessage, IntPtr.Zero);
 			NSString.ReleaseNative (pMessage);
+		}
+
+		public static void Configure ()
+		{
+			Loader.ForceLoad ();
 		}
 	}
 }


### PR DESCRIPTION
* This prevents the linker strip out the Crash Reporting binaries (closes #76)
* This fix the message that you log to Firebase Console when the app crashes (closes #81)