### PR TITLE
Updates needed to add MSFT as NuGet owners

### DIFF
--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.AdMob</id>
     <title>Firebase APIs AdMob iOS Library</title>
     <version>7.24.1.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs AdMob iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosadmob</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosadmob</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865546</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865550</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosadmob_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
+++ b/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.Analytics</id>
     <title>Firebase APIs Analytics iOS Library</title>
     <version>4.0.4.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Analytics iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosanalytics</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosanalytics</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865559</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865564</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosanalytics_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
+++ b/Firebase.Auth/nuget/Xamarin.Firebase.iOS.Auth.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.Auth</id>
     <title>Firebase APIs Auth iOS Library</title>
     <version>4.2.1.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Auth iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosauth</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosauth</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865530</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865534</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosauth_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
+++ b/Firebase.CloudMessaging/nuget/Xamarin.Firebase.iOS.CloudMessaging.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.CloudMessaging</id>
     <title>Firebase APIs Cloud Messaging iOS Library</title>
     <version>2.0.4.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Cloud Messaging iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseioscloudmessaging</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseioscloudmessaging</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865576</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865577</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseioscloudmessaging_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
+++ b/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.Core</id>
     <title>Firebase APIs Core iOS Library</title>
     <version>4.0.8.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Core iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://github.com/xamarin/GoogleApisForiOSComponents/tree/master/Firebase.Core</projectUrl>
-    <licenseUrl>https://github.com/xamarin/GoogleApisForiOSComponents/blob/master/Firebase.Core/License.md/</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865529</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865533</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseioscore_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
+++ b/Firebase.CrashReporting/nuget/Xamarin.Firebase.iOS.CrashReporting.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.CrashReporting</id>
     <title>Firebase APIs Crash Reporting iOS Library</title>
     <version>2.0.0.3</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Crash Reporting iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseioscrashreporting</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseioscrashreporting</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865578</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865531</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseioscrashreporting_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
+++ b/Firebase.Database/nuget/Xamarin.Firebase.iOS.Database.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.Database</id>
     <title>Firebase APIs Database iOS Library</title>
     <version>4.1.0.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Database iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosdatabase</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosdatabase</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865568</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865571</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosdatabase_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
+++ b/Firebase.DynamicLinks/nuget/Xamarin.Firebase.iOS.DynamicLinks.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.DynamicLinks</id>
     <title>Firebase APIs Dynamic Links iOS Library</title>
     <version>2.1.0.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Dynamic Links iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosdynamiclinks</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosdynamiclinks</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865537</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865541</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosdynamiclinks_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
+++ b/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.InstanceID</id>
     <title>Firebase APIs Instance ID iOS Library</title>
     <version>2.0.4.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Instance ID iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://github.com/xamarin/GoogleApisForiOSComponents/tree/master/Firebase.InstanceID</projectUrl>
-    <licenseUrl>https://github.com/xamarin/GoogleApisForiOSComponents/blob/master/Firebase.InstanceID/License.md/</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865551</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865555</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosinstanceid_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
+++ b/Firebase.Invites/nuget/Xamarin.Firebase.iOS.Invites.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.Invites</id>
     <title>Firebase APIs Invites iOS Library</title>
     <version>2.0.1.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Invites iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosinvites</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosinvites</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865563</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865567</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosinvites_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
+++ b/Firebase.RemoteConfig/nuget/Xamarin.Firebase.iOS.RemoteConfig.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.RemoteConfig</id>
     <title>Firebase APIs Remote Config iOS Library</title>
     <version>2.0.3.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Remote Config iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosremoteconfig</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosremoteconfig</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865532</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865536</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosremoteconfig_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
+++ b/Firebase.Storage/nuget/Xamarin.Firebase.iOS.Storage.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Firebase.iOS.Storage</id>
     <title>Firebase APIs Storage iOS Library</title>
     <version>2.0.2.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Firebase APIs Storage iOS Library</description>
-    <copyright>Copyright 2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/firebaseiosstorage</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/firebaseiosstorage</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865545</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865549</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosstorage_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.Analytics/nuget/Xamarin.Google.iOS.Analytics.nuspec
+++ b/Google.Analytics/nuget/Xamarin.Google.iOS.Analytics.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.Analytics</id>
     <title>Google APIs Analytics iOS Library</title>
     <version>3.17.0.2</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Analytics iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosanalytics</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosanalytics</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865535</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865538</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosanalytics_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.AppIndexing/nuget/Xamarin.Google.iOS.AppIndexing.nuspec
+++ b/Google.AppIndexing/nuget/Xamarin.Google.iOS.AppIndexing.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.AppIndexing</id>
     <title>Google APIs App Indexing iOS Library</title>
     <version>2.0.3.4</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs App Indexing iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosappindexing/</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosappindexing</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865556</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865560</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosappindexing_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.AppInvite/nuget/Xamarin.Google.iOS.AppInvite.nuspec
+++ b/Google.AppInvite/nuget/Xamarin.Google.iOS.AppInvite.nuspec
@@ -1,27 +1,27 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>Xamarin.Google.iOS.AppInvite</id>
     <title>Google APIs App Invite iOS Library</title>
     <version>1.0.2.4</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs App Invite iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosappinvite</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosappinvite</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865569</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865573</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosappinvite_128x128.png</iconUrl>
     <dependencies>
-      <dependency id="Xamarin.Build.Download" version="0.4.3"/>
-      <dependency id="Xamarin.Google.iOS.Core" version="2.0.4.1"/>
-      <dependency id="Xamarin.Google.iOS.SignIn" version="3.0.0.1"/>
+      <dependency id="Xamarin.Build.Download" version="0.4.3" />
+      <dependency id="Xamarin.Google.iOS.Core" version="2.0.4.1" />
+      <dependency id="Xamarin.Google.iOS.SignIn" version="3.0.0.1" />
     </dependencies>
   </metadata>
   <files>
     <file src="output/Google.AppInvite.dll" target="lib/Xamarin.iOS10" />
 
     <!-- Add targets file for external native reference download -->
-    <file src="source/Google.AppInvite/Google.AppInvite.targets" target="build/Xamarin.Google.iOS.AppInvite.targets"  />
+    <file src="source/Google.AppInvite/Google.AppInvite.targets" target="build/Xamarin.Google.iOS.AppInvite.targets" />
   </files>
 </package>

--- a/Google.Cast/nuget/Xamarin.Google.iOS.Cast.nuspec
+++ b/Google.Cast/nuget/Xamarin.Google.iOS.Cast.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.Cast</id>
     <title>Google APIs Cast iOS Library</title>
     <version>4.0.2.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Cast iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleioscast</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleioscast</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865570</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865574</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleioscast_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
+++ b/Google.Core/nuget/Xamarin.Google.iOS.Core.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.Core</id>
     <title>Google APIs Core iOS Library</title>
     <version>3.1.0.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Core iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://github.com/xamarin/GoogleApisForiOSComponents/tree/master/Google.Core</projectUrl>
-    <licenseUrl>https://github.com/xamarin/GoogleApisForiOSComponents/blob/master/Google.Core/License.md/</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865540</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865543</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleioscore_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.GoogleCloudMessaging/nuget/Xamarin.Google.iOS.GoogleCloudMessaging.nuspec
+++ b/Google.GoogleCloudMessaging/nuget/Xamarin.Google.iOS.GoogleCloudMessaging.nuspec
@@ -1,27 +1,27 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
     <id>Xamarin.Google.iOS.GoogleCloudMessaging</id>
     <title>Google APIs Google Cloud Messaging iOS Library</title>
     <version>1.2.0.1</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Google Cloud Messaging iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosgcm</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosgcm</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865561</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865565</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosgcm_128x128.png</iconUrl>
     <dependencies>
-      <dependency id="Xamarin.Build.Download" version="0.4.3"/>
-      <dependency id="Xamarin.Google.iOS.Core" version="2.0.4.1"/>
-      <dependency id="Xamarin.Google.iOS.InstanceID" version="1.2.1.1"/>
+      <dependency id="Xamarin.Build.Download" version="0.4.3" />
+      <dependency id="Xamarin.Google.iOS.Core" version="2.0.4.1" />
+      <dependency id="Xamarin.Google.iOS.InstanceID" version="1.2.1.1" />
     </dependencies>
   </metadata>
   <files>
     <file src="output/Google.GoogleCloudMessaging.dll" target="lib/Xamarin.iOS10" />
 
     <!-- Add targets file for external native reference download -->
-    <file src="source/Google.GoogleCloudMessaging/Google.GoogleCloudMessaging.targets" target="build/Xamarin.Google.iOS.GoogleCloudMessaging.targets"  />
+    <file src="source/Google.GoogleCloudMessaging/Google.GoogleCloudMessaging.targets" target="build/Xamarin.Google.iOS.GoogleCloudMessaging.targets" />
   </files>
 </package>

--- a/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
+++ b/Google.InstanceID/nuget/Xamarin.Google.iOS.InstanceID.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.InstanceID</id>
     <title>Google APIs Instance ID iOS Library</title>
     <version>1.2.1.10</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Instance ID iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosinstanceid</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosinstanceid</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865553</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865557</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosinstanceid_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.Maps/nuget/Xamarin.Google.iOS.Maps.nuspec
+++ b/Google.Maps/nuget/Xamarin.Google.iOS.Maps.nuspec
@@ -1,16 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata>
     <id>Xamarin.Google.iOS.Maps</id>
     <title>Google APIs Maps iOS Library</title>
     <version>2.5.0.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Maps iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosmaps</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosmaps</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865548</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865552</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosmaps_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
+++ b/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.MobileAds</id>
     <title>Google APIs Mobile Ads iOS Library</title>
     <version>7.24.1.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Mobile Ads iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosmobileads</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosmobileads</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865562</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865566</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosmobileads_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.Places/nuget/Xamarin.Google.iOS.Places.nuspec
+++ b/Google.Places/nuget/Xamarin.Google.iOS.Places.nuspec
@@ -1,16 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package>
   <metadata>
     <id>Xamarin.Google.iOS.Places</id>
     <title>Google APIs Places iOS Library</title>
     <version>2.5.0.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Places iOS Library</description>
-    <copyright>Copyright 2015-2017 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosplaces</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosplaces</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865542</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865547</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosplaces_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
+++ b/Google.PlayGames/nuget/Xamarin.Google.iOS.PlayGames.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.PlayGames</id>
     <title>Google APIs Play Games iOS Library</title>
     <version>5.1.1.10</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Play Games iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiosplaygames</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiosplaygames</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865572</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865575</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosplaygames_128x128.png</iconUrl>
     <dependencies> 
       <group targetFramework="Xamarin.iOS10">

--- a/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
+++ b/Google.SignIn/nuget/Xamarin.Google.iOS.SignIn.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.SignIn</id>
     <title>Google APIs Sign In iOS Library</title>
     <version>4.1.0.0</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Sign In iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiossignin</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiossignin</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865554</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865558</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiossignin_128x128.png</iconUrl>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">

--- a/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
+++ b/Google.TagManager/nuget/Xamarin.Google.iOS.TagManager.nuspec
@@ -4,13 +4,13 @@
     <id>Xamarin.Google.iOS.TagManager</id>
     <title>Google APIs Tag Manager iOS Library</title>
     <version>6.0.0.1</version>
-    <authors>Xamarin Inc.</authors>
-    <owners>Xamarin Inc.</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>C# bindings for Google APIs Tag Manager iOS Library</description>
-    <copyright>Copyright 2015-2016 Microsoft</copyright>
-    <projectUrl>https://components.xamarin.com/view/googleiostagmanager</projectUrl>
-    <licenseUrl>https://components.xamarin.com/license/googleiostagmanager</licenseUrl>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <projectUrl>https://go.microsoft.com/fwlink/?linkid=865539</projectUrl>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865544</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiostagmanager_128x128.png</iconUrl>
     <dependencies>      
       <group targetFramework="Xamarin.iOS10">


### PR DESCRIPTION
 - Changing to FWLinks for projectUrl and licenseUrl
 - Change authors and authors to "Microsoft"
 - Change copyright to "© Microsoft Corporation. All rights reserved.
 - Require license acceptance for all packages