### PR TITLE
GoogleCast iOS SDK 4.1.0

### DIFF
--- a/Google.Cast/component/component.yaml
+++ b/Google.Cast/component/component.yaml
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.Cast, Version=4.0.2.1
+  - Xamarin.Google.iOS.Cast, Version=4.1.0.0
 samples:
 - name: Cast Sample
   path: ../samples/CastSample/CastSample.sln

--- a/Google.Cast/externals/Podfile
+++ b/Google.Cast/externals/Podfile
@@ -4,5 +4,5 @@ platform :ios, '8.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'GoogleCast' do
-	pod 'google-cast-sdk', '4.0.2'
+	pod 'google-cast-sdk', '4.1.0'
 end

--- a/Google.Cast/nuget/Xamarin.Google.iOS.Cast.nuspec
+++ b/Google.Cast/nuget/Xamarin.Google.iOS.Cast.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.Cast</id>
     <title>Google APIs Cast iOS Library</title>
-    <version>4.0.2.1</version>
+    <version>4.1.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -67,6 +67,24 @@ namespace Google.Cast
 		[Export ("mimeType", ArgumentSemantic.Strong)]
 		string MimeType { get; }
 
+		// @property(nonatomic, strong, readonly, GCK_NULLABLE) NSString *contentID;
+		[NullAllowed]
+		[Export ("contentID", ArgumentSemantic.Strong)]
+		string ContentId { get; }
+
+		// @property(nonatomic, strong, readonly, GCK_NULLABLE) NSURL *posterURL;
+		[NullAllowed]
+		[Export ("posterURL", ArgumentSemantic.Strong)]
+		NSUrl PosterUrl { get; }
+
+		// @property(nonatomic, assign, readonly) NSTimeInterval whenSkippableInMs;
+		[Export ("whenSkippableInMs")]
+		double WhenSkippableInMs { get; }
+
+		// @property(nonatomic, assign, readonly) GCKHLSSegmentFormat hlsSegmentFormat;
+		[Export ("hlsSegmentFormat")]
+		HlsSegmentFormat HlsSegmentFormat { get; }
+
 		// @property(nonatomic, strong, readonly, GCK_NULLABLE) GCKAdBreakClipVastAdsRequest *vastAdsRequest;
 		[NullAllowed]
 		[Export ("vastAdsRequest", ArgumentSemantic.Strong)]
@@ -97,6 +115,10 @@ namespace Google.Cast
 		// @property (readonly, nonatomic, strong) NSArray<NSString *> * _Nonnull adBreakClipIDs;
 		[Export ("adBreakClipIDs", ArgumentSemantic.Strong)]
 		string [] AdBreakClipIds { get; }
+
+		// @property(nonatomic, assign, readonly) BOOL embedded;
+		[Export ("embedded")]
+		bool Embedded { get; }
 
 		// -(instancetype _Nonnull)initWithPlaybackPosition:(NSTimeInterval)playbackPosition;
 		[Export ("initWithPlaybackPosition:")]

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -22,6 +22,19 @@ namespace Google.Cast
 		nint InvalidRequestId { get; }
 	}
 
+	// @interface GCKAdBreakClipVastAdsRequest : NSObject <NSCopying, NSSecureCoding>
+	[BaseType (typeof (NSObject), Name = "GCKAdBreakClipVastAdsRequest")]
+	interface AdBreakClipVastAdsRequest : INSCopying, INSSecureCoding 
+	{
+		// @property(nonatomic, strong, readonly) NSURL *adTagUrl;
+		[Export ("adTagUrl", ArgumentSemantic.Strong)]
+		NSUrl AdTagUrl { get; }
+
+		// @property(nonatomic, strong, readonly) NSString *adsResponse;
+		[Export ("adsResponse", ArgumentSemantic.Strong)]
+		string AdsResponse { get; }
+	}
+
 	// @interface GCKAdBreakClipInfo : NSObject <NSCopying>
 	[BaseType (typeof (NSObject), Name = "GCKAdBreakClipInfo")]
 	interface AdBreakClipInfo : INSCopying, INSSecureCoding
@@ -53,6 +66,11 @@ namespace Google.Cast
 		[NullAllowed]
 		[Export ("mimeType", ArgumentSemantic.Strong)]
 		string MimeType { get; }
+
+		// @property(nonatomic, strong, readonly, GCK_NULLABLE) GCKAdBreakClipVastAdsRequest *vastAdsRequest;
+		[NullAllowed]
+		[Export ("vastAdsRequest", ArgumentSemantic.Strong)]
+		AdBreakClipVastAdsRequest VastAdsRequest { get; }
 
 		// @property (readonly, nonatomic, strong) id _Nullable customData;
 		[NullAllowed]

--- a/Google.Cast/source/Google.Cast/ApiDefinition.cs
+++ b/Google.Cast/source/Google.Cast/ApiDefinition.cs
@@ -848,6 +848,10 @@ namespace Google.Cast
 		// @optional -(void)didRemoveDeviceAtIndex:(NSUInteger)index;
 		[Export ("didRemoveDeviceAtIndex:")]
 		void DidRemoveDevice (nuint index);
+
+        // @optional - (void)didRemoveDevice:(GCKDevice *)device atIndex:(NSUInteger)index;
+        [Export ("didRemoveDevice:atIndex")]
+        void DidRemoveDevice(Device device, nuint index);
 	}
 
 	[DisableDefaultCtor]

--- a/Google.Cast/source/Google.Cast/Google.Cast.targets
+++ b/Google.Cast/source/Google.Cast/Google.Cast.targets
@@ -2,14 +2,14 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleCastAssemblyName>Google.Cast, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleCastAssemblyName>
-		<_GoogleCastItemsFolder>GCst-4.0.2</_GoogleCastItemsFolder>
+		<_GoogleCastItemsFolder>GCst-4.1.0</_GoogleCastItemsFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_GoogleCastItemsFolder)">
-			<Url>https://developers.google.com/cast/downloads/GoogleCastSDK-ios-4.0.2.zip</Url>
+			<Url>https://developers.google.com/cast/downloads/GoogleCastSDK-ios-4.1.0.zip</Url>
 			<Kind>Zip</Kind>
 		</XamarinBuildDownload>
-		<NativeReference Include="$(XamarinBuildDownloadDir)$(_GoogleCastItemsFolder)\GoogleCastSDK-ios-4.0.2\GoogleCast.framework">
+		<NativeReference Include="$(XamarinBuildDownloadDir)$(_GoogleCastItemsFolder)\GoogleCastSDK-ios-4.1.0\GoogleCast.framework">
       		<IsCxx>False</IsCxx>
 			<LinkerFlags>-lc++</LinkerFlags>
 			<Frameworks>Accelerate AudioToolbox AVFoundation CFNetwork CoreBluetooth CoreGraphics CoreMedia CoreText Foundation MediaAccessibility MediaPlayer QuartzCore Security SystemConfiguration UIKit</Frameworks>


### PR DESCRIPTION
This updates the target GoogleCast SDK to use v4.1.0 released on [May 8, 2018](https://developers.google.com/cast/docs/release-notes#march-8-2018)

Changes in the SDK include (copied from the GoogleCast release notes)

- **Ads**
  - Vast Ad format support
  - Added new member fields in `GCKAdBreakInfo` and `GCKAdBreakClipInfo`
- **Cast Overlay Instructions** - updated method to handle a wider variety of cases.
- `DiscoveryManager` has a new method for easier tracking of the removed device.
- **CAF Queues** - Remote media client now has internal support for Queues!
- **Bug Fixes** - Fixed a couple of connectivity issues that prevented reconnection in certain conditions. Also other general bug fixes to improve stability.

A good reason for this to go in A.S.A.P. is that several of our production apps have been reporting crashes regarding `[NSConcreteMutableData initWithCapacity:]: absurd capacity: 18446744073709551588, maximum size: 9223372036854775808 bytes` which is [a known issue from Google](https://issuetracker.google.com/issues/72624903). I haven't gotten a confirmation from Google if v4.1.0 contains the fix but in any case it would be nice to keep the component up to date with the native SDK