### PR TITLE
Enhancement in pod repo update at build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ tmp-nugets
 *.userprefs
 *.DS_Store
 Pods/
-Podfile.lock
 build

--- a/Firebase.AdMob/externals/Makefile
+++ b/Firebase.AdMob/externals/Makefile
@@ -1,12 +1,12 @@
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Firebase.AdMob/externals/Podfile.lock
+++ b/Firebase.AdMob/externals/Podfile.lock
@@ -1,0 +1,41 @@
+PODS:
+  - Firebase/AdMob (4.8.0):
+    - Firebase/Core
+    - Google-Mobile-Ads-SDK (= 7.27.0)
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - Google-Mobile-Ads-SDK (7.27.0)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+
+DEPENDENCIES:
+  - Firebase/AdMob (= 4.8.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  Google-Mobile-Ads-SDK: 83f7f890e638ce8f1debd440ea363338c9f6be3b
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+
+PODFILE CHECKSUM: 457ffd2f2d3c4b955b1f3b25026c936f370083e2
+
+COCOAPODS: 1.4.0

--- a/Firebase.Analytics/externals/Makefile
+++ b/Firebase.Analytics/externals/Makefile
@@ -1,11 +1,11 @@
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock:
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Firebase.Analytics/externals/Podfile.lock
+++ b/Firebase.Analytics/externals/Podfile.lock
@@ -1,0 +1,38 @@
+PODS:
+  - Firebase/Analytics (4.8.0):
+    - Firebase/Core
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+
+DEPENDENCIES:
+  - Firebase/Analytics (= 4.8.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+
+PODFILE CHECKSUM: f97bde2df9d48d68a6fe90b410a00ac5ecc6b11e
+
+COCOAPODS: 1.4.0

--- a/Firebase.Auth/externals/Makefile
+++ b/Firebase.Auth/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Firebase.Auth/externals/Podfile.lock
+++ b/Firebase.Auth/externals/Podfile.lock
@@ -1,0 +1,53 @@
+PODS:
+  - Firebase/Auth (4.8.0):
+    - Firebase/Core
+    - FirebaseAuth (= 4.4.1)
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseAuth (4.4.1):
+    - FirebaseAnalytics (~> 4.0)
+    - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
+    - GTMSessionFetcher/Core (~> 1.1)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - GoogleToolboxForMac/DebugUtils (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.3):
+    - GoogleToolboxForMac/DebugUtils (= 2.1.3)
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
+  - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
+  - GTMSessionFetcher/Core (1.1.14)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+
+DEPENDENCIES:
+  - Firebase/Auth (= 4.8.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseAuth: dc0dd403beca5b2b016aac89c2d0b8dad1c81926
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GTMSessionFetcher: 390ea358e5a0d0133153806f744662dad933d06b
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+
+PODFILE CHECKSUM: 641558ed48c9210b2da0d52d4628d62252c4c4e2
+
+COCOAPODS: 1.4.0

--- a/Firebase.CloudMessaging/externals/Makefile
+++ b/Firebase.CloudMessaging/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Firebase.CloudMessaging/externals/Podfile.lock
+++ b/Firebase.CloudMessaging/externals/Podfile.lock
@@ -1,0 +1,50 @@
+PODS:
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - Firebase/Messaging (4.8.0):
+    - Firebase/Core
+    - FirebaseMessaging (= 2.0.8)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - FirebaseMessaging (2.0.8):
+    - FirebaseAnalytics (~> 4.0)
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/Logger (~> 2.1)
+    - Protobuf (~> 3.1)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/Logger (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+  - Protobuf (3.5.0)
+
+DEPENDENCIES:
+  - Firebase/Messaging (= 4.8.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  FirebaseMessaging: dfdcd307c2382290a1e297a81d0f18370f5b1bcd
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
+
+PODFILE CHECKSUM: 938718a7d6d0526e3a87399d0da649d149cb4039
+
+COCOAPODS: 1.4.0

--- a/Firebase.Core/externals/Makefile
+++ b/Firebase.Core/externals/Makefile
@@ -5,9 +5,9 @@ PROJECT_ROOT=./Pods
 PROJECT=$(PROJECT_ROOT)/Pods.xcodeproj
 TARGETS=GoogleToolboxForMac nanopb GTMSessionFetcher Protobuf
 
-all: Podfile.lock $(TARGETS)
+all: Pods $(TARGETS)
 
-Podfile.lock:
+Pods:
 	$(POD) install
 
 $(TARGETS):
@@ -26,7 +26,7 @@ $(TARGETS):
 	-mv ./build/Release-iphonesimulator/$(currentTarget)/lib$(currentTarget).a $@
 
 clean:
-	@ rm -rf Podfile.lock Pods build
+	@ rm -rf Pods build
 	@ for target in $(TARGETS); do \
         rm -f $$target*; \
 	done

--- a/Firebase.Core/externals/Podfile.lock
+++ b/Firebase.Core/externals/Podfile.lock
@@ -1,0 +1,68 @@
+PODS:
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - GoogleToolboxForMac/Core (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/DebugUtils (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/Logger (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.3):
+    - GoogleToolboxForMac/DebugUtils (= 2.1.3)
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
+  - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
+  - GoogleToolboxForMac/StringEncoding (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/URLBuilder (2.1.3):
+    - GoogleToolboxForMac/Core (= 2.1.3)
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+    - GoogleToolboxForMac/NSDictionary+URLArguments (= 2.1.3)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
+  - GTMSessionFetcher/Core (1.1.12)
+  - GTMSessionFetcher/Full (1.1.12):
+    - GTMSessionFetcher/Core (= 1.1.12)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+  - Protobuf (3.4.0)
+
+DEPENDENCIES:
+  - Firebase/Core (= 4.8.0)
+  - GoogleToolboxForMac/Logger (= 2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (= 2.1.3)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (= 2.1.3)
+  - GoogleToolboxForMac/StringEncoding (= 2.1.3)
+  - GoogleToolboxForMac/URLBuilder (= 2.1.3)
+  - GTMSessionFetcher/Full (= 1.1.12)
+  - nanopb (= 0.3.8)
+  - Protobuf (= 3.4.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Protobuf: 03eef2ee0b674770735cf79d9c4d3659cf6908e8
+
+PODFILE CHECKSUM: c5b16eb4715696c45fd0692bc934550d4e8b36d4
+
+COCOAPODS: 1.4.0

--- a/Firebase.CrashReporting/externals/Makefile
+++ b/Firebase.CrashReporting/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Firebase.CrashReporting/externals/Podfile.lock
+++ b/Firebase.CrashReporting/externals/Podfile.lock
@@ -1,0 +1,43 @@
+PODS:
+  - Firebase/Core (4.0.3):
+    - FirebaseAnalytics (= 4.0.2)
+    - FirebaseCore (= 4.0.3)
+  - Firebase/Crash (4.0.3):
+    - Firebase/Core
+    - FirebaseCrash (= 2.0.0)
+  - FirebaseAnalytics (4.0.2):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseCore (4.0.3):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseCrash (2.0.0):
+    - FirebaseAnalytics (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/Logger (~> 2.1)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - Protobuf (~> 3.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/Logger (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - Protobuf (3.5.0)
+
+DEPENDENCIES:
+  - Firebase/Crash (= 4.0.3)
+
+SPEC CHECKSUMS:
+  Firebase: 9e33fdfbca37cab635c693883caa90a4475b842b
+  FirebaseAnalytics: ad41720e3e67fc63fbe3d2948d3e26932a8de311
+  FirebaseCore: c709067051de07bdaffdc4e735cd7299a23c463a
+  FirebaseCrash: 600ec2cbd8e10c3064a42de2c6ee7687bd02a076
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
+
+PODFILE CHECKSUM: 2556663364219d8313dca4b47d6c3c5ece647c30
+
+COCOAPODS: 1.4.0

--- a/Firebase.Database/externals/Makefile
+++ b/Firebase.Database/externals/Makefile
@@ -5,9 +5,9 @@ PROJECT_ROOT=./Pods
 PROJECT=$(PROJECT_ROOT)/Pods.xcodeproj
 TARGETS=leveldb-library
 
-all: Podfile.lock $(TARGETS)
+all: Pods $(TARGETS)
 
-Podfile.lock:
+Pods:
 	$(POD) install
 
 $(TARGETS):
@@ -26,7 +26,7 @@ $(TARGETS):
 	-mv ./build/Release-iphonesimulator/$(currentTarget)/lib$(currentTarget).a $@
 
 clean:
-	@ rm -rf Podfile.lock Pods build
+	@ rm -rf Pods build
 	@ for target in $(TARGETS); do \
         rm -f $$target*; \
 	done

--- a/Firebase.Database/externals/Podfile.lock
+++ b/Firebase.Database/externals/Podfile.lock
@@ -1,0 +1,47 @@
+PODS:
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - Firebase/Database (4.8.0):
+    - Firebase/Core
+    - FirebaseDatabase (= 4.1.3)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseDatabase (4.1.3):
+    - FirebaseAnalytics (~> 4.0)
+    - FirebaseCore (~> 4.0)
+    - leveldb-library (~> 1.18)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - leveldb-library (1.18.3)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+
+DEPENDENCIES:
+  - Firebase/Database (= 4.8.0)
+  - leveldb-library (= 1.18.3)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseDatabase: 7088bfc4af2cc00231bb36e1404fc2d7509eb4dc
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  leveldb-library: 10fb39c39e243db4af1828441162405bbcec1404
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+
+PODFILE CHECKSUM: 75fa4fda96685af2aae9f29f9fbfeb0f24bca80e
+
+COCOAPODS: 1.4.0

--- a/Firebase.DynamicLinks/externals/Makefile
+++ b/Firebase.DynamicLinks/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Firebase.DynamicLinks/externals/Podfile.lock
+++ b/Firebase.DynamicLinks/externals/Podfile.lock
@@ -1,0 +1,42 @@
+PODS:
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - Firebase/DynamicLinks (4.8.0):
+    - Firebase/Core
+    - FirebaseDynamicLinks (= 2.3.1)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseDynamicLinks (2.3.1):
+    - FirebaseAnalytics (~> 4.0)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+
+DEPENDENCIES:
+  - Firebase/DynamicLinks (= 4.8.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseDynamicLinks: b708fbc1e9bd77c2d992812736b206820e283203
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+
+PODFILE CHECKSUM: 6f8bc76cc7b94254d3ad53e0a68019fb8a5befb1
+
+COCOAPODS: 1.4.0

--- a/Firebase.InstanceID/externals/Makefile
+++ b/Firebase.InstanceID/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Firebase.InstanceID/externals/Podfile.lock
+++ b/Firebase.InstanceID/externals/Podfile.lock
@@ -1,0 +1,20 @@
+PODS:
+  - FirebaseCore (4.0.17):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.8):
+    - FirebaseCore (~> 4.0)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+
+DEPENDENCIES:
+  - FirebaseInstanceID (= 2.0.8)
+
+SPEC CHECKSUMS:
+  FirebaseCore: 872307b001bbefda1dfa0dbfffa50a6919023d4a
+  FirebaseInstanceID: 81df5805a08001e69138664bdd02c6719a9ac80f
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+
+PODFILE CHECKSUM: fad4c231bdb797faf16556d4ab70dbd3fa347045
+
+COCOAPODS: 1.4.0

--- a/Firebase.Invites/externals/Makefile
+++ b/Firebase.Invites/externals/Makefile
@@ -5,9 +5,9 @@ PROJECT_ROOT=./Pods
 PROJECT=$(PROJECT_ROOT)/Pods.xcodeproj
 TARGETS=GoogleAPIClientForREST
 
-all: Podfile.lock $(TARGETS)
+all: Pods $(TARGETS)
 
-Podfile.lock:
+Pods:
 	$(POD) install
 
 $(TARGETS):
@@ -26,7 +26,7 @@ $(TARGETS):
 	-mv ./build/Release-iphonesimulator/$(currentTarget)/lib$(currentTarget).a $@
 
 clean:
-	@ rm -rf Podfile.lock Pods build
+	@ rm -rf Pods build
 	@ for target in $(TARGETS); do \
         rm -f $$target*; \
 	done

--- a/Firebase.Invites/externals/Podfile.lock
+++ b/Firebase.Invites/externals/Podfile.lock
@@ -1,0 +1,99 @@
+PODS:
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - Firebase/Invites (4.8.0):
+    - Firebase/Core
+    - FirebaseInvites (= 2.0.2)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseDynamicLinks (2.3.2):
+    - FirebaseAnalytics (~> 4.0)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - FirebaseInvites (2.0.2):
+    - FirebaseAnalytics (~> 4.0)
+    - FirebaseDynamicLinks (~> 2.2)
+    - GoogleAPIClientForREST (~> 1.0)
+    - GoogleSignIn (~> 4.1)
+    - GoogleToolboxForMac/Logger (~> 2.1)
+    - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
+    - GoogleToolboxForMac/NSString+URLArguments (~> 2.1)
+    - GoogleToolboxForMac/StringEncoding (~> 2.1)
+    - GoogleToolboxForMac/URLBuilder (~> 2.1)
+    - GTMOAuth2 (~> 1.0)
+    - GTMSessionFetcher/Core (~> 1.1)
+    - GTMSessionFetcher/Full (~> 1.1)
+    - Protobuf (~> 3.1)
+  - GoogleAPIClientForREST (1.3.2):
+    - GoogleAPIClientForREST/Core (= 1.3.2)
+    - GTMSessionFetcher (>= 1.1.7)
+  - GoogleAPIClientForREST/Core (1.3.2):
+    - GTMSessionFetcher (>= 1.1.7)
+  - GoogleSignIn (4.1.2):
+    - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
+    - GoogleToolboxForMac/NSString+URLArguments (~> 2.1)
+    - GTMOAuth2 (~> 1.0)
+    - GTMSessionFetcher/Core (~> 1.1)
+  - GoogleToolboxForMac/Core (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/DebugUtils (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/Logger (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.3):
+    - GoogleToolboxForMac/DebugUtils (= 2.1.3)
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
+  - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
+  - GoogleToolboxForMac/StringEncoding (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/URLBuilder (2.1.3):
+    - GoogleToolboxForMac/Core (= 2.1.3)
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+    - GoogleToolboxForMac/NSDictionary+URLArguments (= 2.1.3)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
+  - GTMOAuth2 (1.1.6):
+    - GTMSessionFetcher (~> 1.1)
+  - GTMSessionFetcher (1.1.14):
+    - GTMSessionFetcher/Full (= 1.1.14)
+  - GTMSessionFetcher/Core (1.1.14)
+  - GTMSessionFetcher/Full (1.1.14):
+    - GTMSessionFetcher/Core (= 1.1.14)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+  - Protobuf (3.5.0)
+
+DEPENDENCIES:
+  - Firebase/Invites (= 4.8.0)
+  - GoogleAPIClientForREST (= 1.3.2)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseDynamicLinks: 38b68641d24e78d0277a9205d988ce22875d5a25
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  FirebaseInvites: ae15e0636f9eb42bdf5c1ef4c8f7bd4a88f9878b
+  GoogleAPIClientForREST: 4fa84fc61fdeea48dd7088de5c1a864ace18125b
+  GoogleSignIn: d9ef55b10f0aa401a5de2747f59b725e4b9732ac
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GTMOAuth2: c77fe325e4acd453837e72d91e3b5f13116857b2
+  GTMSessionFetcher: 390ea358e5a0d0133153806f744662dad933d06b
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
+
+PODFILE CHECKSUM: 5ef036e0426864f126cb10f64ddf578cd8b3b0e8
+
+COCOAPODS: 1.4.0

--- a/Firebase.PerformanceMonitoring/externals/Makefile
+++ b/Firebase.PerformanceMonitoring/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Firebase.PerformanceMonitoring/externals/Podfile.lock
+++ b/Firebase.PerformanceMonitoring/externals/Podfile.lock
@@ -1,0 +1,56 @@
+PODS:
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - Firebase/Performance (4.8.0):
+    - Firebase/Core
+    - FirebasePerformance (= 1.1.0)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - FirebasePerformance (1.1.0):
+    - FirebaseAnalytics (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - FirebaseSwizzlingUtilities (~> 1.0)
+    - GoogleToolboxForMac/Logger (~> 2.1)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - GTMSessionFetcher/Core (~> 1.1)
+    - Protobuf (~> 3.1)
+  - FirebaseSwizzlingUtilities (1.0.0)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/Logger (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GTMSessionFetcher/Core (1.1.14)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+  - Protobuf (3.5.0)
+
+DEPENDENCIES:
+  - Firebase/Performance (= 4.8.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  FirebasePerformance: 3877d097c59956aa2d7a317dbae503c2b4e78459
+  FirebaseSwizzlingUtilities: f1c49a5a372ac852c853722a5891a0a5e2344a6c
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GTMSessionFetcher: 390ea358e5a0d0133153806f744662dad933d06b
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
+
+PODFILE CHECKSUM: d90098b24cc105fee886c557574db28844c13123
+
+COCOAPODS: 1.4.0

--- a/Firebase.RemoteConfig/externals/Makefile
+++ b/Firebase.RemoteConfig/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Firebase.RemoteConfig/externals/Podfile.lock
+++ b/Firebase.RemoteConfig/externals/Podfile.lock
@@ -1,0 +1,48 @@
+PODS:
+  - Firebase/Core (4.3.0):
+    - FirebaseAnalytics (= 4.0.4)
+    - FirebaseCore (= 4.0.8)
+  - Firebase/RemoteConfig (4.3.0):
+    - Firebase/Core
+    - FirebaseRemoteConfig (= 2.0.3)
+  - FirebaseAnalytics (4.0.4):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.8):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - FirebaseRemoteConfig (2.0.3):
+    - FirebaseAnalytics (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - Protobuf (~> 3.1)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+  - Protobuf (3.5.0)
+
+DEPENDENCIES:
+  - Firebase/RemoteConfig (= 4.3.0)
+
+SPEC CHECKSUMS:
+  Firebase: 83283761a1ef6dc9846e03d08059f51421afbd65
+  FirebaseAnalytics: 722b53c7b32bfc7806b06e0093a2f5180d4f2c5a
+  FirebaseCore: 69b1a5ac5f857ba6d5fd9d5fe794f4786dd5e579
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  FirebaseRemoteConfig: 1c982f73af48ec048c8fa8621d5178cfdffac9aa
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
+
+PODFILE CHECKSUM: e11be3deed885d078f60c7d2bbd442dbdfeb7135
+
+COCOAPODS: 1.4.0

--- a/Firebase.Storage/externals/Makefile
+++ b/Firebase.Storage/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Firebase.Storage/externals/Podfile.lock
+++ b/Firebase.Storage/externals/Podfile.lock
@@ -1,0 +1,46 @@
+PODS:
+  - Firebase/Core (4.8.0):
+    - FirebaseAnalytics (= 4.0.5)
+    - FirebaseCore (= 4.0.13)
+  - Firebase/Storage (4.8.0):
+    - Firebase/Core
+    - FirebaseStorage (= 2.1.1)
+  - FirebaseAnalytics (4.0.5):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.13):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - FirebaseStorage (2.1.1):
+    - FirebaseAnalytics (~> 4.0)
+    - FirebaseCore (~> 4.0)
+    - GTMSessionFetcher/Core (~> 1.1)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GTMSessionFetcher/Core (1.1.14)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+
+DEPENDENCIES:
+  - Firebase/Storage (= 4.8.0)
+
+SPEC CHECKSUMS:
+  Firebase: 710decbbc6d9d48530e9a5dba3209740c3532e05
+  FirebaseAnalytics: 5b02a63ead2c3f0259cfc7f15e053e440587ecf8
+  FirebaseCore: 3c02ec652db3d03fdc8bc6d9154af3e20d64b6f5
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  FirebaseStorage: ab08d1c93a2feffa038fdd6693088b310ab1e6c6
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GTMSessionFetcher: 390ea358e5a0d0133153806f744662dad933d06b
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+
+PODFILE CHECKSUM: cacb215aa8bb81d5ff403dd595a4ef5c78f7d9c6
+
+COCOAPODS: 1.4.0

--- a/Google.Analytics/externals/Makefile
+++ b/Google.Analytics/externals/Makefile
@@ -1,11 +1,11 @@
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock:
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Google.Analytics/externals/Podfile.lock
+++ b/Google.Analytics/externals/Podfile.lock
@@ -1,0 +1,12 @@
+PODS:
+  - GoogleAnalytics (3.17.0)
+
+DEPENDENCIES:
+  - GoogleAnalytics (= 3.17.0)
+
+SPEC CHECKSUMS:
+  GoogleAnalytics: f42cc53a87a51fe94334821868d9c8481ff47a7b
+
+PODFILE CHECKSUM: e2e1aca97498dabc1f3fd0f427548a87e7a8277f
+
+COCOAPODS: 1.4.0

--- a/Google.AppIndexing/externals/Makefile
+++ b/Google.AppIndexing/externals/Makefile
@@ -1,12 +1,12 @@
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Google.AppIndexing/externals/Podfile.lock
+++ b/Google.AppIndexing/externals/Podfile.lock
@@ -1,0 +1,12 @@
+PODS:
+  - GoogleAppIndexing (2.0.3)
+
+DEPENDENCIES:
+  - GoogleAppIndexing (= 2.0.3)
+
+SPEC CHECKSUMS:
+  GoogleAppIndexing: 176146164d14b30a403f5ba394fc2b51855025da
+
+PODFILE CHECKSUM: 886486b529cbb7bf68e61f338f4d21ef80d736e8
+
+COCOAPODS: 1.4.0

--- a/Google.AppInvite/externals/Makefile
+++ b/Google.AppInvite/externals/Makefile
@@ -6,9 +6,9 @@ INFODIRS=Pods
 POD=pod
 
 
-all: Podfile.lock Info.plist
+all: Pods Info.plist
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 ### Temporary workaround. Removes the CFBundleExecutable key from Info.plist files that causes Apple rejection.
@@ -25,7 +25,7 @@ Info.plist:
 ###
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Google.AppInvite/externals/Podfile.lock
+++ b/Google.AppInvite/externals/Podfile.lock
@@ -1,0 +1,68 @@
+PODS:
+  - AppInvites (1.0.2):
+    - GoogleInterchangeUtilities (~> 1.0)
+    - GooglePlusUtilities (~> 1.0)
+    - GPPCore (~> 1.8)
+  - Google/AppInvite (1.1.0):
+    - AppInvites (~> 1.0)
+    - Google/Core
+    - Google/SignIn
+  - Google/Core (1.1.0):
+    - GoogleInterchangeUtilities (~> 1.0)
+    - GoogleNetworkingUtilities (~> 1.0)
+    - GoogleSymbolUtilities (~> 1.0)
+    - GoogleUtilities (~> 1.1)
+  - Google/SignIn (1.1.0):
+    - Google/Core
+    - GoogleSignIn (~> 2.0)
+  - GoogleAppUtilities (1.1.2):
+    - GoogleSymbolUtilities (~> 1.1)
+  - GoogleAuthUtilities (1.0.1):
+    - GoogleNetworkingUtilities (~> 1.0)
+    - GoogleSymbolUtilities (~> 1.0)
+  - GoogleInterchangeUtilities (1.2.2):
+    - GoogleSymbolUtilities (~> 1.1)
+  - GoogleNetworkingUtilities (1.2.2):
+    - GoogleSymbolUtilities (~> 1.1)
+  - GoogleParsingUtilities (1.1.2):
+    - GoogleNetworkingUtilities (~> 1.2)
+    - GoogleSymbolUtilities (~> 1.1)
+  - GooglePlusUtilities (1.1.2):
+    - GoogleParsingUtilities (~> 1.1)
+    - GoogleSymbolUtilities (~> 1.1)
+  - GoogleSignIn (2.4.0):
+    - GoogleAppUtilities (~> 1.0)
+    - GoogleAuthUtilities (~> 1.0)
+    - GoogleNetworkingUtilities (~> 1.0)
+    - GoogleUtilities (~> 1.0)
+  - GoogleSymbolUtilities (1.1.2)
+  - GoogleUtilities (1.3.2):
+    - GoogleSymbolUtilities (~> 1.1)
+  - GPPCore (1.8.1):
+    - GoogleAppUtilities (~> 1.0)
+    - GoogleAuthUtilities (~> 1.0)
+    - GoogleParsingUtilities (~> 1.0)
+    - GoogleSignIn (~> 2)
+    - GoogleUtilities (~> 1.0)
+
+DEPENDENCIES:
+  - AppInvites (= 1.0.2)
+  - Google/AppInvite (= 1.1.0)
+
+SPEC CHECKSUMS:
+  AppInvites: d2852d42e22714a67decc8e5809c8c63cc7b8b8f
+  Google: 7594f024f48e8929f1fe25f01d84a60c9abb6acd
+  GoogleAppUtilities: a8a552aa74f6597f805e45b5a3962766c3134973
+  GoogleAuthUtilities: 049ffd3a297cdffd271451b82fd4e75304f15ef3
+  GoogleInterchangeUtilities: d5bc4d88d5b661ab72f9d70c58d02ca8c27ad1f7
+  GoogleNetworkingUtilities: 3edd3a8161347494f2da60ea0deddc8a472d94cb
+  GoogleParsingUtilities: d265e86f84c1ab595f6ca5172b22a7a10ce99e1f
+  GooglePlusUtilities: d4e722b8f26650681eab3e53da8fd7bd4d1922b4
+  GoogleSignIn: 79929b51e6299c69f1197bbd9c7a1367d523ecd8
+  GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
+  GoogleUtilities: 8bbc733218aad26306f9d4a253823986110e3358
+  GPPCore: 228fdd19eba0e83cba6817004f0d6431d8396d64
+
+PODFILE CHECKSUM: 2fd81a49bb4c53e5039bbba34c9759f559010fa6
+
+COCOAPODS: 1.4.0

--- a/Google.Cast/externals/Makefile
+++ b/Google.Cast/externals/Makefile
@@ -1,11 +1,11 @@
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Google.Cast/externals/Podfile.lock
+++ b/Google.Cast/externals/Podfile.lock
@@ -1,0 +1,14 @@
+PODS:
+  - google-cast-sdk (4.0.2):
+    - google-cast-sdk/Core (= 4.0.2)
+  - google-cast-sdk/Core (4.0.2)
+
+DEPENDENCIES:
+  - google-cast-sdk (= 4.0.2)
+
+SPEC CHECKSUMS:
+  google-cast-sdk: 64e135f63f6c1d7d8e5ea8d240ae6c918877ce62
+
+PODFILE CHECKSUM: 8033fd5a4f61d6ef4c2a23c563a12acd2c0a71ba
+
+COCOAPODS: 1.4.0

--- a/Google.Core/externals/Makefile
+++ b/Google.Core/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Google.Core/externals/Podfile.lock
+++ b/Google.Core/externals/Podfile.lock
@@ -1,0 +1,28 @@
+PODS:
+  - FirebaseAnalytics (3.9.0):
+    - FirebaseCore (~> 3.6)
+    - FirebaseInstanceID (~> 1.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseCore (3.6.0):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (1.0.10):
+    - FirebaseCore (~> 3.6)
+  - Google/Core (3.1.0):
+    - FirebaseAnalytics (~> 3.2)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+
+DEPENDENCIES:
+  - Google/Core (= 3.1.0)
+
+SPEC CHECKSUMS:
+  FirebaseAnalytics: e5fe8486efc01bec33f6bf82e2fa9fce4b124052
+  FirebaseCore: 9691ee2ade70c098d7cf92440f4303f16d83ca75
+  FirebaseInstanceID: b9eedd6846fb5e1f0f7279e1deaa7a7e4cf8392e
+  Google: 98da4b1a60ed0beb80a290387a28333406a1eb90
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+
+PODFILE CHECKSUM: 7fcbeaac3a1bba5ae85ee94c2d14c595a5089524
+
+COCOAPODS: 1.4.0

--- a/Google.GoogleCloudMessaging/externals/Makefile
+++ b/Google.GoogleCloudMessaging/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Google.GoogleCloudMessaging/externals/Podfile.lock
+++ b/Google.GoogleCloudMessaging/externals/Podfile.lock
@@ -1,0 +1,45 @@
+PODS:
+  - GGLInstanceID (1.2.1)
+  - Google/CloudMessaging (2.0.3):
+    - GGLInstanceID (~> 1.0)
+    - Google/Core
+    - GoogleCloudMessaging (~> 1.0)
+  - Google/Core (2.0.3):
+    - GoogleInterchangeUtilities (~> 1.0)
+    - GoogleNetworkingUtilities (~> 1.0)
+    - GoogleSymbolUtilities (~> 1.0)
+    - GoogleUtilities (~> 1.1)
+  - GoogleCloudMessaging (1.1.2):
+    - GoogleInterchangeUtilities (~> 1.0)
+    - GoogleIPhoneUtilities (~> 1.0)
+    - GoogleNetworkingUtilities (~> 1.0)
+    - GoogleSymbolUtilities (~> 1.0)
+    - GoogleUtilities (~> 1.0)
+  - GoogleInterchangeUtilities (1.2.2):
+    - GoogleSymbolUtilities (~> 1.1)
+  - GoogleIPhoneUtilities (1.2.1):
+    - GoogleSymbolUtilities (~> 1.0)
+    - GoogleUtilities (~> 1.0)
+  - GoogleNetworkingUtilities (1.2.2):
+    - GoogleSymbolUtilities (~> 1.1)
+  - GoogleSymbolUtilities (1.1.2)
+  - GoogleUtilities (1.3.2):
+    - GoogleSymbolUtilities (~> 1.1)
+
+DEPENDENCIES:
+  - Google/CloudMessaging (= 2.0.3)
+  - GoogleCloudMessaging (= 1.1.2)
+
+SPEC CHECKSUMS:
+  GGLInstanceID: 4a317044f744281b82cd03015f379899f277cad3
+  Google: b256691df67064b88d45d4fb472d43e1fe8bb202
+  GoogleCloudMessaging: faa057e30845e7300da31de3777060420b2f6579
+  GoogleInterchangeUtilities: d5bc4d88d5b661ab72f9d70c58d02ca8c27ad1f7
+  GoogleIPhoneUtilities: 63f25e93a3ddcb66884d182aab3a660d98f1479b
+  GoogleNetworkingUtilities: 3edd3a8161347494f2da60ea0deddc8a472d94cb
+  GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
+  GoogleUtilities: 8bbc733218aad26306f9d4a253823986110e3358
+
+PODFILE CHECKSUM: aa87120e4e68ddf06db3fe8a55e8610028de4406
+
+COCOAPODS: 1.4.0

--- a/Google.InstanceID/externals/Makefile
+++ b/Google.InstanceID/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Google.InstanceID/externals/Podfile.lock
+++ b/Google.InstanceID/externals/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - GGLInstanceID (1.2.1)
+  - GoogleIPhoneUtilities (1.2.0):
+    - GoogleSymbolUtilities (~> 1.0)
+    - GoogleUtilities (~> 1.0)
+  - GoogleSymbolUtilities (1.1.2)
+  - GoogleUtilities (1.3.2):
+    - GoogleSymbolUtilities (~> 1.1)
+
+DEPENDENCIES:
+  - GGLInstanceID (= 1.2.1)
+  - GoogleIPhoneUtilities (= 1.2.0)
+
+SPEC CHECKSUMS:
+  GGLInstanceID: 4a317044f744281b82cd03015f379899f277cad3
+  GoogleIPhoneUtilities: 1c2996078f079d2fc54453dbd13eaf5523666550
+  GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
+  GoogleUtilities: 8bbc733218aad26306f9d4a253823986110e3358
+
+PODFILE CHECKSUM: a8f6a338aa6c5c69da474eacfabf371e4c623064
+
+COCOAPODS: 1.4.0

--- a/Google.Maps/externals/Makefile
+++ b/Google.Maps/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Google.Maps/externals/Podfile.lock
+++ b/Google.Maps/externals/Podfile.lock
@@ -1,0 +1,16 @@
+PODS:
+  - GoogleMaps (2.5.0):
+    - GoogleMaps/Maps (= 2.5.0)
+  - GoogleMaps/Base (2.5.0)
+  - GoogleMaps/Maps (2.5.0):
+    - GoogleMaps/Base
+
+DEPENDENCIES:
+  - GoogleMaps (= 2.5.0)
+
+SPEC CHECKSUMS:
+  GoogleMaps: c087b8e5dfe87ca6ebf59adb9b4894a4146bec4f
+
+PODFILE CHECKSUM: 2ee5a563e9bda8c41b1e02c42c1d792460ec48dd
+
+COCOAPODS: 1.4.0

--- a/Google.MobileAds/externals/Makefile
+++ b/Google.MobileAds/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock:
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Google.MobileAds/externals/Podfile.lock
+++ b/Google.MobileAds/externals/Podfile.lock
@@ -1,0 +1,12 @@
+PODS:
+  - Google-Mobile-Ads-SDK (7.27.0)
+
+DEPENDENCIES:
+  - Google-Mobile-Ads-SDK (= 7.27.0)
+
+SPEC CHECKSUMS:
+  Google-Mobile-Ads-SDK: 83f7f890e638ce8f1debd440ea363338c9f6be3b
+
+PODFILE CHECKSUM: 2c9c18fec3eed46e1a062162e475247d3880dfad
+
+COCOAPODS: 1.4.0

--- a/Google.Places/externals/Makefile
+++ b/Google.Places/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Google.Places/externals/Podfile.lock
+++ b/Google.Places/externals/Podfile.lock
@@ -1,0 +1,24 @@
+PODS:
+  - GoogleMaps (2.5.0):
+    - GoogleMaps/Maps (= 2.5.0)
+  - GoogleMaps/Base (2.5.0)
+  - GoogleMaps/Maps (2.5.0):
+    - GoogleMaps/Base
+  - GooglePlacePicker (2.5.0):
+    - GoogleMaps (= 2.5.0)
+    - GooglePlaces (= 2.5.0)
+  - GooglePlaces (2.5.0):
+    - GoogleMaps/Base (= 2.5.0)
+
+DEPENDENCIES:
+  - GooglePlacePicker (= 2.5.0)
+  - GooglePlaces (= 2.5.0)
+
+SPEC CHECKSUMS:
+  GoogleMaps: c087b8e5dfe87ca6ebf59adb9b4894a4146bec4f
+  GooglePlacePicker: 1573e644ab54564d95c2643edc0f29091609e966
+  GooglePlaces: dd70d9d71ea1c7944846afe67de3712c99b30a77
+
+PODFILE CHECKSUM: 8dad7bdaa5730b2f5618795aa41ead194429a297
+
+COCOAPODS: 1.4.0

--- a/Google.PlayGames/externals/Makefile
+++ b/Google.PlayGames/externals/Makefile
@@ -1,12 +1,12 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock:
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean

--- a/Google.PlayGames/externals/Podfile.lock
+++ b/Google.PlayGames/externals/Podfile.lock
@@ -1,0 +1,40 @@
+PODS:
+  - GooglePlayGames (5.1.1):
+    - GooglePlusOpenSource (>= 1.7.1)
+    - GoogleSignIn (>= 2.2.0)
+  - GooglePlusOpenSource (1.7.1)
+  - GoogleSignIn (4.1.2):
+    - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
+    - GoogleToolboxForMac/NSString+URLArguments (~> 2.1)
+    - GTMOAuth2 (~> 1.0)
+    - GTMSessionFetcher/Core (~> 1.1)
+  - GoogleToolboxForMac/DebugUtils (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.3):
+    - GoogleToolboxForMac/DebugUtils (= 2.1.3)
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
+  - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
+  - GTMOAuth2 (1.1.6):
+    - GTMSessionFetcher (~> 1.1)
+  - GTMSessionFetcher (1.1.14):
+    - GTMSessionFetcher/Full (= 1.1.14)
+  - GTMSessionFetcher/Core (1.1.14)
+  - GTMSessionFetcher/Full (1.1.14):
+    - GTMSessionFetcher/Core (= 1.1.14)
+
+DEPENDENCIES:
+  - GooglePlayGames (= 5.1.1)
+
+SPEC CHECKSUMS:
+  GooglePlayGames: 3b4fdd70647f74a711695265d61eb9a64334d38d
+  GooglePlusOpenSource: 5d514063287e1e87060eb4f9fab9d23d1c8fa601
+  GoogleSignIn: d9ef55b10f0aa401a5de2747f59b725e4b9732ac
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GTMOAuth2: c77fe325e4acd453837e72d91e3b5f13116857b2
+  GTMSessionFetcher: 390ea358e5a0d0133153806f744662dad933d06b
+
+PODFILE CHECKSUM: 60cc7f0dc69c5da0a76988083f54b77f0a8c3475
+
+COCOAPODS: 1.4.0

--- a/Google.SignIn/externals/Makefile
+++ b/Google.SignIn/externals/Makefile
@@ -5,9 +5,9 @@ PROJECT_ROOT=./Pods
 PROJECT=$(PROJECT_ROOT)/Pods.xcodeproj
 TARGETS=GTMOAuth2
 
-all: Podfile.lock $(TARGETS)
+all: Pods $(TARGETS)
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 $(TARGETS):
@@ -26,7 +26,7 @@ $(TARGETS):
 	-mv ./build/Release-iphonesimulator/$(currentTarget)/lib$(currentTarget).a $@
 
 clean:
-	@ rm -rf Podfile.lock Pods build
+	@ rm -rf Pods build
 	@ for target in $(TARGETS); do \
 	rm -f $$target*; \
 	done

--- a/Google.SignIn/externals/Podfile.lock
+++ b/Google.SignIn/externals/Podfile.lock
@@ -1,0 +1,35 @@
+PODS:
+  - GoogleSignIn (4.1.1):
+    - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
+    - GoogleToolboxForMac/NSString+URLArguments (~> 2.1)
+    - GTMOAuth2 (~> 1.0)
+    - GTMSessionFetcher/Core (~> 1.1)
+  - GoogleToolboxForMac/DebugUtils (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.3):
+    - GoogleToolboxForMac/DebugUtils (= 2.1.3)
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
+  - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
+  - GTMOAuth2 (1.1.5):
+    - GTMSessionFetcher (~> 1.1)
+  - GTMSessionFetcher (1.1.14):
+    - GTMSessionFetcher/Full (= 1.1.14)
+  - GTMSessionFetcher/Core (1.1.14)
+  - GTMSessionFetcher/Full (1.1.14):
+    - GTMSessionFetcher/Core (= 1.1.14)
+
+DEPENDENCIES:
+  - GoogleSignIn (= 4.1.1)
+  - GTMOAuth2 (= 1.1.5)
+
+SPEC CHECKSUMS:
+  GoogleSignIn: 3fdaa34a2ba04dbd7a25d7db39aecb0da98d5bdc
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GTMOAuth2: be83fd28d63ae3087e7d351b1f39c1a7e24ab6e7
+  GTMSessionFetcher: 390ea358e5a0d0133153806f744662dad933d06b
+
+PODFILE CHECKSUM: 5e3e8b653c7ab0491b60b4d256d5ab7cf793b706
+
+COCOAPODS: 1.4.0

--- a/Google.TagManager/externals/Makefile
+++ b/Google.TagManager/externals/Makefile
@@ -1,13 +1,13 @@
 
 POD=pod
 
-all: Podfile.lock
+all: Pods
 
-Podfile.lock :
+Pods:
 	$(POD) install
 
 clean:
-	rm -rf Podfile.lock Pods
+	rm -rf Pods
 
 .PHONY: all clean
 

--- a/Google.TagManager/externals/Podfile.lock
+++ b/Google.TagManager/externals/Podfile.lock
@@ -1,0 +1,44 @@
+PODS:
+  - FirebaseAnalytics (4.1.0):
+    - FirebaseCore (~> 4.0)
+    - FirebaseInstanceID (~> 2.0)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+    - nanopb (~> 0.3)
+  - FirebaseCore (4.0.17):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseInstanceID (2.0.9):
+    - FirebaseCore (~> 4.0)
+  - GoogleAnalytics (3.17.0)
+  - GoogleSymbolUtilities (1.1.2)
+  - GoogleTagManager (6.0.0):
+    - FirebaseAnalytics (~> 4.0)
+    - GoogleAnalytics (~> 3.17)
+    - GoogleUtilities (~> 1.3)
+  - GoogleToolboxForMac/Defines (2.1.3)
+  - GoogleToolboxForMac/NSData+zlib (2.1.3):
+    - GoogleToolboxForMac/Defines (= 2.1.3)
+  - GoogleUtilities (1.3.2):
+    - GoogleSymbolUtilities (~> 1.1)
+  - nanopb (0.3.8):
+    - nanopb/decode (= 0.3.8)
+    - nanopb/encode (= 0.3.8)
+  - nanopb/decode (0.3.8)
+  - nanopb/encode (0.3.8)
+
+DEPENDENCIES:
+  - GoogleTagManager (= 6.0.0)
+
+SPEC CHECKSUMS:
+  FirebaseAnalytics: 3dfae28d4a5e06f86c4fae830efc2ad3fadb19bc
+  FirebaseCore: 872307b001bbefda1dfa0dbfffa50a6919023d4a
+  FirebaseInstanceID: d2058a35e9bebda1b6dd42486b84917bde552a9d
+  GoogleAnalytics: f42cc53a87a51fe94334821868d9c8481ff47a7b
+  GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
+  GoogleTagManager: 07acea48abe73aac17550b81bbf52a37db2d7dd6
+  GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
+  GoogleUtilities: 8bbc733218aad26306f9d4a253823986110e3358
+  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+
+PODFILE CHECKSUM: a9d9172b20b7f0081a39f8dbb8896d69f4025682
+
+COCOAPODS: 1.4.0

--- a/build.cake
+++ b/build.cake
@@ -2,6 +2,7 @@
 #addin nuget:?package=Cake.FileHelpers&version=1.0.3.2
 #addin nuget:?package=Cake.Yaml&version=1.0.3
 #addin nuget:?package=Cake.Json&version=1.0.2
+#addin nuget:?package=Cake.XCode&version=2.0.9
 
 var TARGET = Argument ("target", Argument ("t", Argument ("Target", "build")));
 
@@ -19,6 +20,8 @@ var BUILD_TARGETS = Argument ("targets", Argument ("build-targets", Argument ("b
 
 var FORCE_BUILD = Argument ("force", Argument ("forcebuild", Argument ("force-build", "false"))).ToLower ().Equals ("true");
 
+var POD_REPO_UPDATE = Argument ("update", Argument ("repo-update", Argument ("pod-repo-update", false)));
+
 // Print out environment variables to console
 var ENV_VARS = EnvironmentVariables ();
 Information ("Environment Variables: {0}", "");
@@ -35,6 +38,12 @@ Information ("Git Path: {0}", GIT_PATH);
 Information ("Git Previous Commit: {0}", GIT_PREVIOUS_COMMIT);
 Information ("Git Commit: {0}", GIT_COMMIT);
 Information ("Force Build: {0}", FORCE_BUILD);
+
+public enum PodRepoUpdate {
+	NotRequired,
+	Required,
+	Forced
+}
 
 public class CakeStealer
 {
@@ -78,7 +87,7 @@ IEnumerable<string> ExecuteProcess (string file, string args)
 	return stdout;
 }
 
-void BuildGroups (List<BuildGroup> buildGroups, List<string> names, List<string> buildTargets, string gitPath, string gitBranch, string gitPreviousCommit, string gitCommit, bool forceBuild)
+void BuildGroups (List<BuildGroup> buildGroups, List<string> names, List<string> buildTargets, string gitPath, string gitBranch, string gitPreviousCommit, string gitCommit, bool forceBuild, PodRepoUpdate podRepoUpdate)
 {
 	bool runningOnMac = IsRunningOnUnix ();
 	bool runningOnWin = IsRunningOnWindows ();
@@ -116,6 +125,9 @@ void BuildGroups (List<BuildGroup> buildGroups, List<string> names, List<string>
 		Information ("Changed Files:");
 		foreach (var file in changedFiles) {
 			Information ("\t{0}", file);
+
+			if (podRepoUpdate == PodRepoUpdate.NotRequired && file.EndsWith ("Podfile"))
+				podRepoUpdate = PodRepoUpdate.Required;
 
 			foreach (var buildGroup in buildGroups) {
 				// If ignore triggers for the platform this is running on, do not add the group even if the trigger is matched
@@ -167,6 +179,25 @@ void BuildGroups (List<BuildGroup> buildGroups, List<string> names, List<string>
 				buildGroup.BuildTargets.Clear ();
 				buildGroup.BuildTargets.AddRange (buildTargets);				
 			}	
+		}
+
+		if (podRepoUpdate != PodRepoUpdate.NotRequired) {
+			string message = string.Empty;
+			if (podRepoUpdate == PodRepoUpdate.Forced)
+				message = "Forcing Cocoapods repo update...";
+			else
+				message = "A modified Podfile was found...";
+
+			Information ("////////////////////////////////////////");
+			Information ("// Pods Repo Update Started           //");
+			Information ("////////////////////////////////////////");
+			
+			Information ($"{message}\nUpdating Cocoapods repo...");
+			CocoaPodRepoUpdate ();
+
+			Information ("////////////////////////////////////////");
+			Information ("// Pods Repo Update Ended             //");
+			Information ("////////////////////////////////////////");
 		}
 		
 		if (!DirectoryExists ("./output/"))
@@ -273,7 +304,9 @@ Task ("build").Does (() =>
 		Information ("Overriding build group names to: {0}", string.Join (", ", BUILD_NAMES));
 	}
 
-	BuildGroups (BUILD_GROUPS, BUILD_NAMES.ToList (), buildTargets, GIT_PATH, GIT_BRANCH, GIT_PREVIOUS_COMMIT, GIT_COMMIT, FORCE_BUILD);		
+	PodRepoUpdate podRepoUpdate = POD_REPO_UPDATE ? PodRepoUpdate.Forced : PodRepoUpdate.NotRequired;
+
+	BuildGroups (BUILD_GROUPS, BUILD_NAMES.ToList (), buildTargets, GIT_PATH, GIT_BRANCH, GIT_PREVIOUS_COMMIT, GIT_COMMIT, FORCE_BUILD, podRepoUpdate);		
 });
 
 RunTarget (TARGET);

--- a/common.cake
+++ b/common.cake
@@ -28,8 +28,10 @@ string [] MyDependencies = null;
 Task ("externals")
 	.Does (() => 
 {
+	if (DirectoryExists ("./externals/Pods/"))
+		return;
+
 	InvokeOtherGoogleModules (MyDependencies, "externals");
-	CocoaPodRepoUpdate ();
 	RunMake ("./externals/", "all");
 });
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -38,6 +38,10 @@
   BuildScript: ./Firebase.Invites/build.cake
   TriggerPaths: [ Firebase.Invites ]
   MacBuildTargets: [ samples, component ]
+- Name: Firebase.iOS.PerformanceMonitoring
+  BuildScript: ./Firebase.PerformanceMonitoring/build.cake
+  TriggerPaths: [ Firebase.PerformanceMonitoring ]
+  MacBuildTargets: [ samples, component ]
 - Name: Firebase.iOS.RemoteConfig
   BuildScript: ./Firebase.RemoteConfig/build.cake
   TriggerPaths: [ Firebase.RemoteConfig ]
@@ -97,8 +101,4 @@
 - Name: Google.iOS.TagManager
   BuildScript: ./Google.TagManager/build.cake
   TriggerPaths: [ Google.TagManager ]
-  MacBuildTargets: [ samples, component ]
-- Name: Firebase.PerformanceMonitoring
-  BuildScript: ./Firebase.PerformanceMonitoring/build.cake
-  TriggerPaths: [ Firebase.PerformanceMonitoring ]
   MacBuildTargets: [ samples, component ]


### PR DESCRIPTION
* This reduces the build time of all components from 2:30-3:00 hrs to 30 min aprox. (This time is based on my local machine build time, at server side could be less time).
* `pod repo update` command will be executed once only when necessary at the start of the build process.
* According to this [CocoaPods Blog][1], to avoid that `pod install` command runs `pod repo update`, it must find the **Podfile.lock** file, so, this file is not being ignored anymore.

[1]: http://blog.cocoapods.org/Master-Spec-Repo-Rate-Limiting-Post-Mortem/