### PR TITLE
[Google][MobileAds] Don't specify an existing native type as the exported type for the MediatedNativeAd model.

### DIFF
--- a/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
+++ b/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
@@ -2109,7 +2109,7 @@ namespace Google.MobileAds
 	// @protocol GADMediatedNativeAd <NSObject>
 	[Model]
 	[Protocol]
-	[BaseType (typeof (NSObject), Name = "GADMediatedNativeAd")]
+	[BaseType (typeof (NSObject), Name = "Google_MobileAds_MediatedNativeAd")]
 	interface MediatedNativeAd
 	{
 		// @required -(id<GADMediatedNativeAdDelegate>)mediatedNativeAdDelegate;


### PR DESCRIPTION
This fixes a build problem with Xamarin.iOS d15-7:

    MTOUCH : error MT5212: Native linking failed, duplicate symbol: '_OBJC_CLASS_$_GADMediatedNativeAd'.
    MTOUCH : error MT5213: Duplicate symbol in: /Users/rolf/Projects/testproj/testproj/obj/iPhoneSimulator/Debug/mtouch-cache/x86_64/registrar.o (Location related to previous error)
    MTOUCH : error MT5213: Duplicate symbol in: /Users/rolf/Projects/testproj/testproj/obj/iPhoneSimulator/Debug/mtouch-cache/GoogleMobileAds(flat-x86_64) (Location related to previous error)
    MTOUCH : error MT5212: Native linking failed, duplicate symbol: '_OBJC_METACLASS_$_GADMediatedNativeAd'.
    MTOUCH : error MT5213: Duplicate symbol in: /Users/rolf/Projects/testproj/testproj/obj/iPhoneSimulator/Debug/mtouch-cache/x86_64/registrar.o (Location related to previous error)
    MTOUCH : error MT5213: Duplicate symbol in: /Users/rolf/Projects/testproj/testproj/obj/iPhoneSimulator/Debug/mtouch-cache/GoogleMobileAds(flat-x86_64) (Location related to previous error)

This was reported here: https://github.com/xamarin/xamarin-macios/issues/3830#issuecomment-387755664