### PR TITLE
[Firebase][Crashlytics] Renamed bad method name in samples

### DIFF
--- a/Firebase.Crashlytics/component/GettingStarted.md
+++ b/Firebase.Crashlytics/component/GettingStarted.md
@@ -27,6 +27,7 @@
 		- [What about NSExceptions?](#what-about-nsexceptions)
 	- [Manage Crash Insights data](#manage-crash-insights-data)
 - [Extend Firebase Crashlytics with Cloud Functions](#extend-firebase-crashlytics-with-cloud-functions)
+- [Known issues](#known-issues)
 
 ## Before you begin
 
@@ -347,6 +348,17 @@ Crash Insights uses aggregated crash data to identify common stability trends. I
 You can trigger a function in response to Crashlytics issue events including new issues, regressed issues, and velocity alerts. To learn more about this, please, read the following [documentation][3].
 
 ---
+
+# Known issues
+
+* Error `Native linking failed, duplicate symbol '_main'` appears when you try to build for **iPhoneSimulator**. A workaround for this is to change the behavior of the **Registrar**:
+	1. Open your project settings
+	2. Go to **Build** tab
+	3. Select **iOS Build** option
+	4. Type `--registrar:static` in **Additional mtouch arguments** textbox
+	5. Click on **Ok**
+
+	Don't forget to add this in **Release** and **Debug** configuration of **iPhoneSimulator** platform.
 
 <sub>_Portions of this page are modifications based on work created and [shared by Google](https://developers.google.com/readme/policies/) and used according to terms described in the [Creative Commons 3.0 Attribution License](http://creativecommons.org/licenses/by/3.0/). Click [here](https://firebase.google.com/docs/crashlytics/get-started) to see original Firebase documentation._</sub>
 

--- a/Firebase.Crashlytics/samples/CrashlyticsSample/CrashlyticsSample/CrashlyticsSample.csproj
+++ b/Firebase.Crashlytics/samples/CrashlyticsSample/CrashlyticsSample/CrashlyticsSample.csproj
@@ -29,6 +29,7 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>pdbonly</DebugType>
@@ -56,6 +57,7 @@
     <MtouchArch>i386, x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--registrar:static</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Firebase.Crashlytics/samples/CrashlyticsSample/CrashlyticsSample/ViewController.cs
+++ b/Firebase.Crashlytics/samples/CrashlyticsSample/CrashlyticsSample/ViewController.cs
@@ -45,7 +45,7 @@ namespace CrashlyticsSample {
 			var nsData = NSDictionary.FromObjectsAndKeys (data.Values.ToArray (), data.Keys.ToArray (), data.Keys.Count);
 
 			Logging.NSLogCallerInformation ($"Hi! Maybe I'm about to crash! Here's some data: {nsData}", nameof (ViewController));
-			Crashlytics.SharedInstance.SetObjectValue (nsData, "data");
+			Crashlytics.SharedInstance.SetValue (nsData, "data");
 
 			Crashlytics.SharedInstance.Crash ();
 		}

--- a/Firebase.Crashlytics/source/Firebase.Crashlytics.sln
+++ b/Firebase.Crashlytics/source/Firebase.Crashlytics.sln
@@ -3,6 +3,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Firebase.Crashlytics", "Firebase.Crashlytics\Firebase.Crashlytics.csproj", "{6D907852-5442-4CCF-BDD5-8941194D6AD6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Firebase.Core", "..\..\Firebase.Core\source\Firebase.Core\Firebase.Core.csproj", "{0AD1ED63-C008-41B3-8ADB-04696B4880E3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Firebase.InstanceID", "..\..\Firebase.InstanceID\source\Firebase.InstanceID\Firebase.InstanceID.csproj", "{D6AA184C-DA45-4BBB-988A-451B20C7B804}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Firebase.Analytics", "..\..\Firebase.Analytics\source\Firebase.Analytics\Firebase.Analytics.csproj", "{87BB564C-85A8-4EC1-AD16-EC0A1ACCEE56}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,5 +19,17 @@ Global
 		{6D907852-5442-4CCF-BDD5-8941194D6AD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D907852-5442-4CCF-BDD5-8941194D6AD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D907852-5442-4CCF-BDD5-8941194D6AD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AD1ED63-C008-41B3-8ADB-04696B4880E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AD1ED63-C008-41B3-8ADB-04696B4880E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AD1ED63-C008-41B3-8ADB-04696B4880E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AD1ED63-C008-41B3-8ADB-04696B4880E3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6AA184C-DA45-4BBB-988A-451B20C7B804}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6AA184C-DA45-4BBB-988A-451B20C7B804}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6AA184C-DA45-4BBB-988A-451B20C7B804}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6AA184C-DA45-4BBB-988A-451B20C7B804}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87BB564C-85A8-4EC1-AD16-EC0A1ACCEE56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87BB564C-85A8-4EC1-AD16-EC0A1ACCEE56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87BB564C-85A8-4EC1-AD16-EC0A1ACCEE56}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87BB564C-85A8-4EC1-AD16-EC0A1ACCEE56}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Firebase.Crashlytics/source/Firebase.Crashlytics/Firebase.Crashlytics.csproj
+++ b/Firebase.Crashlytics/source/Firebase.Crashlytics/Firebase.Crashlytics.csproj
@@ -48,5 +48,19 @@
   <ItemGroup>
     <None Include="Firebase.Crashlytics.targets" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Firebase.Analytics\source\Firebase.Analytics\Firebase.Analytics.csproj">
+      <Project>{87BB564C-85A8-4EC1-AD16-EC0A1ACCEE56}</Project>
+      <Name>Firebase.Analytics</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Firebase.Core\source\Firebase.Core\Firebase.Core.csproj">
+      <Project>{0AD1ED63-C008-41B3-8ADB-04696B4880E3}</Project>
+      <Name>Firebase.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Firebase.InstanceID\source\Firebase.InstanceID\Firebase.InstanceID.csproj">
+      <Project>{D6AA184C-DA45-4BBB-988A-451B20C7B804}</Project>
+      <Name>Firebase.InstanceID</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.ObjCBinding.CSharp.targets" />
 </Project>

--- a/Firebase.Crashlytics/source/Firebase.Crashlytics/Loader.cs
+++ b/Firebase.Crashlytics/source/Firebase.Crashlytics/Loader.cs
@@ -14,6 +14,9 @@ namespace ApiDefinition {
 	partial class Messaging {
 		static Messaging ()
 		{
+			Firebase.Core.Loader.ForceLoad ();
+			Firebase.InstanceID.Loader.ForceLoad ();
+			Firebase.Analytics.Loader.ForceLoad ();
 			Firebase.Crashlytics.Loader.ForceLoad ();
 		}
 	}


### PR DESCRIPTION
* Added `--registrar:static` to sample and documented workaround
* Added F.Core, F.InstanceID and F.Analytics project references to Crashlytics binding project