### PR TITLE
[Fix] [Google.MobileAds] Change BaseType MediaView from NSObject to UIView

### DIFF
--- a/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
+++ b/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
@@ -2555,7 +2555,7 @@ namespace Google.MobileAds {
 	}
 
 	// @interface GADMediaView : UIView
-	[BaseType (typeof (NSObject), Name = "GADMediaView")]
+	[BaseType (typeof (UIView), Name = "GADMediaView")]
 	interface MediaView {
 	}
 


### PR DESCRIPTION
- Changed basetype of `MediaView` from `NSObject` to `UIView`
- This fixes #166 