### PR TITLE
[Update] Firebase AdMob for iOS v7.38.0

### DIFF
--- a/Firebase.AdMob/build.cake
+++ b/Firebase.AdMob/build.cake
@@ -6,7 +6,10 @@ var TARGET = Argument ("t", Argument ("target", "Default"));
 buildSpec = new BuildSpec () {
 
 	Samples = new ISolutionBuilder [] {
-		new IOSSolutionBuilder { SolutionPath = "./samples/AdMobSample/AdMobSample.sln", Configuration = "Release", BuildsOn = BuildPlatforms.Mac }, 
+		new IOSSolutionBuilder { SolutionPath = "./samples/AdMobSample/AdMobSample.sln", Configuration = "Release", BuildsOn = BuildPlatforms.Mac,
+		Properties = new Dictionary<string, List<string>> {
+			{ "MtouchArch", new List<string> { "ARM64" } }
+		} },
 	},
 
 	NuGets = new [] {

--- a/Firebase.AdMob/component/component.yaml
+++ b/Firebase.AdMob/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.32.0.1
+version: 7.37.0.0
 name: Firebase AdMob for iOS
 id: firebaseiosadmob
 publisher: Xamarin Inc
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.AdMob, Version=7.32.0.1
+  - Xamarin.Firebase.iOS.AdMob, Version=7.37.0.0
 samples:
 - name: AdMob Sample
   path: ../samples/AdMobSample/AdMobSample.sln

--- a/Firebase.AdMob/component/component.yaml
+++ b/Firebase.AdMob/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.37.0.0
+version: 7.38.0.0
 name: Firebase AdMob for iOS
 id: firebaseiosadmob
 publisher: Xamarin Inc
@@ -18,7 +18,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.AdMob, Version=7.37.0.0
+  - Xamarin.Firebase.iOS.AdMob, Version=7.38.0.0
 samples:
 - name: AdMob Sample
   path: ../samples/AdMobSample/AdMobSample.sln

--- a/Firebase.AdMob/externals/Podfile
+++ b/Firebase.AdMob/externals/Podfile
@@ -1,11 +1,11 @@
 =begin
 Last run Firebase/AdMob installed:
-* Firebase (5.15.0)
-* FirebaseAnalytics (5.4.0)
-* FirebaseCore (5.1.10)
-* FirebaseInstanceID (3.3.0)
-* Google-Mobile-Ads-SDK (7.37.0)
-* GoogleAppMeasurement (5.4.0)
+* Firebase (5.16.0)
+* FirebaseAnalytics (5.5.0)
+* FirebaseCore (5.2.0)
+* FirebaseInstanceID (3.4.0)
+* Google-Mobile-Ads-SDK (7.38.0)
+* GoogleAppMeasurement (5.5.0)
 * GoogleUtilities (5.3.7)
 * nanopb (0.3.901)
 
@@ -14,20 +14,20 @@ If yes, please, update *.targets files located in binding
 projects, also, update Podfile files if needed.
 
 In Google.MobileAds binding project, you can find the .targets file of:
-* Google-Mobile-Ads-SDK (7.37.0)
+* Google-Mobile-Ads-SDK (7.38.0)
 
 and the Native Reference of:
 * PersonalizedAdConsent (1.0.3)
 
 In Firebase.Analytics binding project, you can find the .targets file of:
-* FirebaseAnalytics (5.4.0)
-* GoogleAppMeasurement (5.4.0)
+* FirebaseAnalytics (5.5.0)
+* GoogleAppMeasurement (5.5.0)
 
 In Firebase.InstanceID binding project, you can find the .targets file of:
-* FirebaseInstanceID (3.3.0)
+* FirebaseInstanceID (3.4.0)
 
 In Firebase.Core binding project, you can find the Native Reference of:
-* FirebaseCore (5.1.10)
+* FirebaseCore (5.2.0)
 * GoogleUtilities (5.3.7)
 * nanopb (0.3.901)
 =end
@@ -39,5 +39,5 @@ install! 'cocoapods', :integrate_targets => false
 use_frameworks!
 
 target 'FirebaseAdMob' do
-	pod 'Firebase/AdMob', '5.15.0'
+	pod 'Firebase/AdMob', '5.16.0'
 end 

--- a/Firebase.AdMob/externals/Podfile
+++ b/Firebase.AdMob/externals/Podfile
@@ -1,35 +1,35 @@
 =begin
 Last run Firebase/AdMob installed:
-* Firebase (5.8.1)
-* FirebaseAnalytics (5.1.4)
-* FirebaseCore (5.1.3)
-* FirebaseInstanceID (3.2.1)
-* Google-Mobile-Ads-SDK (7.32.0)
-* GoogleAppMeasurement (5.1.4)
-* GoogleUtilities (5.3.0)
-* nanopb (0.3.8)
+* Firebase (5.15.0)
+* FirebaseAnalytics (5.4.0)
+* FirebaseCore (5.1.10)
+* FirebaseInstanceID (3.3.0)
+* Google-Mobile-Ads-SDK (7.37.0)
+* GoogleAppMeasurement (5.4.0)
+* GoogleUtilities (5.3.7)
+* nanopb (0.3.901)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In Google.MobileAds binding project, you can find the .targets file of:
-* Google-Mobile-Ads-SDK (7.32.0)
+* Google-Mobile-Ads-SDK (7.37.0)
 
 and the Native Reference of:
 * PersonalizedAdConsent (1.0.3)
 
 In Firebase.Analytics binding project, you can find the .targets file of:
-* FirebaseAnalytics (5.1.4)
-* GoogleAppMeasurement (5.1.4)
+* FirebaseAnalytics (5.4.0)
+* GoogleAppMeasurement (5.4.0)
 
 In Firebase.InstanceID binding project, you can find the .targets file of:
-* FirebaseInstanceID (3.2.1)
+* FirebaseInstanceID (3.3.0)
 
 In Firebase.Core binding project, you can find the Native Reference of:
-* FirebaseCore (5.1.3)
-* GoogleUtilities (5.3.0)
-* nanopb (0.3.8)
+* FirebaseCore (5.1.10)
+* GoogleUtilities (5.3.7)
+* nanopb (0.3.901)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -39,5 +39,5 @@ install! 'cocoapods', :integrate_targets => false
 use_frameworks!
 
 target 'FirebaseAdMob' do
-	pod 'Firebase/AdMob', '5.8.1'
+	pod 'Firebase/AdMob', '5.15.0'
 end 

--- a/Firebase.AdMob/externals/Podfile.lock
+++ b/Firebase.AdMob/externals/Podfile.lock
@@ -1,71 +1,71 @@
 PODS:
-  - Firebase/AdMob (5.8.1):
+  - Firebase/AdMob (5.15.0):
     - Firebase/Core
-    - Google-Mobile-Ads-SDK (~> 7.32)
-  - Firebase/Core (5.8.1):
+    - Google-Mobile-Ads-SDK (~> 7.37)
+  - Firebase/Core (5.15.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 5.1.4)
-  - Firebase/CoreOnly (5.8.1):
-    - FirebaseCore (= 5.1.3)
-  - FirebaseAnalytics (5.1.4):
+    - FirebaseAnalytics (= 5.4.0)
+  - Firebase/CoreOnly (5.15.0):
+    - FirebaseCore (= 5.1.10)
+  - FirebaseAnalytics (5.4.0):
     - FirebaseCore (~> 5.1)
-    - FirebaseInstanceID (~> 3.2)
-    - GoogleAppMeasurement (~> 5.1)
+    - FirebaseInstanceID (~> 3.3)
+    - GoogleAppMeasurement (= 5.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
     - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
     - GoogleUtilities/NSData+zlib (~> 5.2)
     - nanopb (~> 0.3)
-  - FirebaseCore (5.1.3):
+  - FirebaseCore (5.1.10):
     - GoogleUtilities/Logger (~> 5.2)
-  - FirebaseInstanceID (3.2.2):
+  - FirebaseInstanceID (3.3.0):
     - FirebaseCore (~> 5.1)
     - GoogleUtilities/Environment (~> 5.3)
     - GoogleUtilities/UserDefaults (~> 5.3)
-  - Google-Mobile-Ads-SDK (7.34.0)
-  - GoogleAppMeasurement (5.2.0):
+  - Google-Mobile-Ads-SDK (7.38.0)
+  - GoogleAppMeasurement (5.4.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
     - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
     - GoogleUtilities/NSData+zlib (~> 5.2)
     - nanopb (~> 0.3)
-  - GoogleUtilities/AppDelegateSwizzler (5.3.0):
+  - GoogleUtilities/AppDelegateSwizzler (5.3.7):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (5.3.0)
-  - GoogleUtilities/Logger (5.3.0):
+  - GoogleUtilities/Environment (5.3.7)
+  - GoogleUtilities/Logger (5.3.7):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (5.3.0):
+  - GoogleUtilities/MethodSwizzler (5.3.7):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (5.3.0):
+  - GoogleUtilities/Network (5.3.7):
     - GoogleUtilities/Logger
     - GoogleUtilities/NSData+zlib
     - GoogleUtilities/Reachability
-  - GoogleUtilities/NSData+zlib (5.3.0)
-  - GoogleUtilities/Reachability (5.3.0):
+  - GoogleUtilities/NSData+zlib (5.3.7)
+  - GoogleUtilities/Reachability (5.3.7):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (5.3.0):
+  - GoogleUtilities/UserDefaults (5.3.7):
     - GoogleUtilities/Logger
-  - nanopb (0.3.8):
-    - nanopb/decode (= 0.3.8)
-    - nanopb/encode (= 0.3.8)
-  - nanopb/decode (0.3.8)
-  - nanopb/encode (0.3.8)
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
 
 DEPENDENCIES:
-  - Firebase/AdMob (= 5.8.1)
+  - Firebase/AdMob (= 5.15.0)
 
 SPEC CHECKSUMS:
-  Firebase: a870ed114d769b424021a0c8ddb0c86c3250a0c5
-  FirebaseAnalytics: 361594968a84a04d9598ef0f2e769d3735cd03de
-  FirebaseCore: 27bd80e5bfaaf9552a1f5cacb4c7e8bb925bab22
-  FirebaseInstanceID: 78ba376fcd5b94c001f9999b2cbd3d1f1e56e78d
-  Google-Mobile-Ads-SDK: a1cbce28c0c78ca1fb0b6c4f213485f55527c99f
-  GoogleAppMeasurement: 2b3a023a61239c8d002e6e4fcf4abce8eddce0e0
-  GoogleUtilities: 760ccb53b7c7f40f9c02d8c241f76f841a7a6162
-  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Firebase: 8bb9268bff82374f2cbaaabb143e725743c316ae
+  FirebaseAnalytics: c06f9d70577d79074214700a71fd5d39de5550fb
+  FirebaseCore: 35747502d9e8c6ee217385ad04446c7c2aaf9c5c
+  FirebaseInstanceID: e2fa4cb35ef5558c200f7f0ad8a53e212215f93e
+  Google-Mobile-Ads-SDK: fec4a72b71a81302d3fd75454df3417c03c50ed5
+  GoogleAppMeasurement: 98b71f5e04142793729a5ef23e5b96651ff4b70f
+  GoogleUtilities: 111a012f4c3a29c9e7c954c082fafd6ee3c999c0
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
 
-PODFILE CHECKSUM: 8bff947e413db5e85454d6ebaad28a20a18f2ef7
+PODFILE CHECKSUM: 5bad3bb7ef4a554495062a2893d9a27085ad8a90
 
 COCOAPODS: 1.4.0

--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.AdMob</id>
     <title>Firebase APIs AdMob iOS Library</title>
-    <version>7.37.0.0</version>
+    <version>7.38.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,10 +15,10 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.37.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="5.4.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.3.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.10.0" />
+        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.38.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="5.5.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.4.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="5.2.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.AdMob</id>
     <title>Firebase APIs AdMob iOS Library</title>
-    <version>7.32.0.1</version>
+    <version>7.37.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,10 +15,10 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.32.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.Analytics" version="5.1.4.1" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.2.1.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.3.0" />
+        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.37.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Analytics" version="5.4.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.3.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.10.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
+++ b/Firebase.AdMob/nuget/Xamarin.Firebase.iOS.AdMob.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.AdMob</id>
     <title>Firebase APIs AdMob iOS Library</title>
-    <version>7.38.0.0</version>
+    <version>7.38.0.0-beta1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -12,10 +12,11 @@
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=865546</projectUrl>
     <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865550</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/firebaseiosadmob_128x128.png</iconUrl>
+    <releaseNotes>This package has an issue with armv7 arch due missing symbols, which may cause not to work properly on some devices. This issue has been reported to Google.</releaseNotes>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.38.0.0" />
+        <dependency id="Xamarin.Google.iOS.MobileAds" version="7.38.0.0-beta1" />
         <dependency id="Xamarin.Firebase.iOS.Analytics" version="5.5.0.0" />
         <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.4.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="5.2.0.0" />

--- a/Firebase.Analytics/component/component.yaml
+++ b/Firebase.Analytics/component/component.yaml
@@ -1,4 +1,4 @@
-version: 5.1.4.1
+version: 5.4.0.0
 name: Firebase Analytics for iOS
 id: firebaseiosanalytics
 publisher: Xamarin Inc.
@@ -17,7 +17,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Analytics, Version=5.1.4.1
+  - Xamarin.Firebase.iOS.Analytics, Version=5.4.0.0
 samples:
 - name: Analytics Sample
   path: ../samples/AnalyticsSample/AnalyticsSample.sln

--- a/Firebase.Analytics/component/component.yaml
+++ b/Firebase.Analytics/component/component.yaml
@@ -1,4 +1,4 @@
-version: 5.4.0.0
+version: 5.5.0.0
 name: Firebase Analytics for iOS
 id: firebaseiosanalytics
 publisher: Xamarin Inc.
@@ -17,7 +17,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.Analytics, Version=5.4.0.0
+  - Xamarin.Firebase.iOS.Analytics, Version=5.5.0.0
 samples:
 - name: Analytics Sample
   path: ../samples/AnalyticsSample/AnalyticsSample.sln

--- a/Firebase.Analytics/externals/Podfile
+++ b/Firebase.Analytics/externals/Podfile
@@ -1,10 +1,10 @@
 =begin
 Last run FirebaseAnalytics installed:
-* Firebase (5.15.0)
-* FirebaseAnalytics (5.4.0)
-* FirebaseCore (5.1.10)
-* FirebaseInstanceID (3.3.0)
-* GoogleAppMeasurement (5.4.0)
+* Firebase (5.16.0)
+* FirebaseAnalytics (5.5.0)
+* FirebaseCore (5.2.0)
+* FirebaseInstanceID (3.4.0)
+* GoogleAppMeasurement (5.5.0)
 * GoogleUtilities (5.3.7)
 * nanopb (0.3.901)
 
@@ -13,14 +13,14 @@ If yes, please, update *.targets files located in binding
 projects, also, update Podfile files if needed.
 
 In Firebase.Analytics binding project, you can find the .targets file of:
-* FirebaseAnalytics (5.4.0)
-* GoogleAppMeasurement (5.4.0)
+* FirebaseAnalytics (5.5.0)
+* GoogleAppMeasurement (5.5.0)
 
 In Firebase.InstanceID binding project, you can find the .targets file of:
-* FirebaseInstanceID (3.3.0)
+* FirebaseInstanceID (3.4.0)
 
 In Firebase.Core binding project, you can find the Native Reference of:
-* FirebaseCore (5.1.10)
+* FirebaseCore (5.2.0)
 * GoogleUtilities (5.3.7)
 * nanopb (0.3.901)
 =end
@@ -31,6 +31,6 @@ platform :ios, '8.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseAnalytics' do
-	pod 'Firebase/Analytics', '5.15.0'
-	pod 'GoogleAppMeasurement', '5.4.0'
+	pod 'Firebase/Analytics', '5.16.0'
+	pod 'GoogleAppMeasurement', '5.5.0'
 end

--- a/Firebase.Analytics/externals/Podfile
+++ b/Firebase.Analytics/externals/Podfile
@@ -1,28 +1,28 @@
 =begin
 Last run FirebaseAnalytics installed:
-* Firebase (5.8.1)
-* FirebaseAnalytics (5.1.4)
-* FirebaseCore (5.1.3)
-* FirebaseInstanceID (3.2.1)
-* GoogleAppMeasurement (5.1.4)
-* GoogleUtilities (5.3.0)
-* nanopb (0.3.8)
+* Firebase (5.15.0)
+* FirebaseAnalytics (5.4.0)
+* FirebaseCore (5.1.10)
+* FirebaseInstanceID (3.3.0)
+* GoogleAppMeasurement (5.4.0)
+* GoogleUtilities (5.3.7)
+* nanopb (0.3.901)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets files located in binding 
 projects, also, update Podfile files if needed.
 
 In Firebase.Analytics binding project, you can find the .targets file of:
-* FirebaseAnalytics (5.1.4)
-* GoogleAppMeasurement (5.1.4)
+* FirebaseAnalytics (5.4.0)
+* GoogleAppMeasurement (5.4.0)
 
 In Firebase.InstanceID binding project, you can find the .targets file of:
-* FirebaseInstanceID (3.2.1)
+* FirebaseInstanceID (3.3.0)
 
 In Firebase.Core binding project, you can find the Native Reference of:
-* FirebaseCore (5.1.3)
-* GoogleUtilities (5.3.0)
-* nanopb (0.3.8)
+* FirebaseCore (5.1.10)
+* GoogleUtilities (5.3.7)
+* nanopb (0.3.901)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -31,6 +31,6 @@ platform :ios, '8.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseAnalytics' do
-	pod 'Firebase/Analytics', '5.8.1'
-	pod 'GoogleAppMeasurement', '5.1.4'
+	pod 'Firebase/Analytics', '5.15.0'
+	pod 'GoogleAppMeasurement', '5.4.0'
 end

--- a/Firebase.Analytics/externals/Podfile.lock
+++ b/Firebase.Analytics/externals/Podfile.lock
@@ -1,66 +1,69 @@
 PODS:
-  - Firebase/Analytics (5.8.1):
+  - Firebase/Analytics (5.15.0):
     - Firebase/Core
-  - Firebase/Core (5.8.1):
+  - Firebase/Core (5.15.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 5.1.4)
-  - Firebase/CoreOnly (5.8.1):
-    - FirebaseCore (= 5.1.3)
-  - FirebaseAnalytics (5.1.4):
+    - FirebaseAnalytics (= 5.4.0)
+  - Firebase/CoreOnly (5.15.0):
+    - FirebaseCore (= 5.1.10)
+  - FirebaseAnalytics (5.4.0):
     - FirebaseCore (~> 5.1)
-    - FirebaseInstanceID (~> 3.2)
-    - GoogleAppMeasurement (~> 5.1)
+    - FirebaseInstanceID (~> 3.3)
+    - GoogleAppMeasurement (= 5.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
     - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
     - GoogleUtilities/NSData+zlib (~> 5.2)
     - nanopb (~> 0.3)
-  - FirebaseCore (5.1.3):
+  - FirebaseCore (5.1.10):
     - GoogleUtilities/Logger (~> 5.2)
-  - FirebaseInstanceID (3.2.1):
+  - FirebaseInstanceID (3.3.0):
     - FirebaseCore (~> 5.1)
-    - GoogleUtilities/Environment (~> 5.2)
-  - GoogleAppMeasurement (5.1.4):
+    - GoogleUtilities/Environment (~> 5.3)
+    - GoogleUtilities/UserDefaults (~> 5.3)
+  - GoogleAppMeasurement (5.4.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
     - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
     - GoogleUtilities/NSData+zlib (~> 5.2)
     - nanopb (~> 0.3)
-  - GoogleUtilities/AppDelegateSwizzler (5.3.0):
+  - GoogleUtilities/AppDelegateSwizzler (5.3.7):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (5.3.0)
-  - GoogleUtilities/Logger (5.3.0):
+  - GoogleUtilities/Environment (5.3.7)
+  - GoogleUtilities/Logger (5.3.7):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (5.3.0):
+  - GoogleUtilities/MethodSwizzler (5.3.7):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (5.3.0):
+  - GoogleUtilities/Network (5.3.7):
     - GoogleUtilities/Logger
     - GoogleUtilities/NSData+zlib
     - GoogleUtilities/Reachability
-  - GoogleUtilities/NSData+zlib (5.3.0)
-  - GoogleUtilities/Reachability (5.3.0):
+  - GoogleUtilities/NSData+zlib (5.3.7)
+  - GoogleUtilities/Reachability (5.3.7):
     - GoogleUtilities/Logger
-  - nanopb (0.3.8):
-    - nanopb/decode (= 0.3.8)
-    - nanopb/encode (= 0.3.8)
-  - nanopb/decode (0.3.8)
-  - nanopb/encode (0.3.8)
+  - GoogleUtilities/UserDefaults (5.3.7):
+    - GoogleUtilities/Logger
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
 
 DEPENDENCIES:
-  - Firebase/Analytics (= 5.8.1)
-  - GoogleAppMeasurement (= 5.1.4)
+  - Firebase/Analytics (= 5.15.0)
+  - GoogleAppMeasurement (= 5.4.0)
 
 SPEC CHECKSUMS:
-  Firebase: a870ed114d769b424021a0c8ddb0c86c3250a0c5
-  FirebaseAnalytics: 361594968a84a04d9598ef0f2e769d3735cd03de
-  FirebaseCore: 27bd80e5bfaaf9552a1f5cacb4c7e8bb925bab22
-  FirebaseInstanceID: ea5af6920d0a4a29b40459d055bebe4a6c1333c4
-  GoogleAppMeasurement: 7d2552cea4e12d09ce737ef0441887a746585ff3
-  GoogleUtilities: 760ccb53b7c7f40f9c02d8c241f76f841a7a6162
-  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  Firebase: 8bb9268bff82374f2cbaaabb143e725743c316ae
+  FirebaseAnalytics: c06f9d70577d79074214700a71fd5d39de5550fb
+  FirebaseCore: 35747502d9e8c6ee217385ad04446c7c2aaf9c5c
+  FirebaseInstanceID: e2fa4cb35ef5558c200f7f0ad8a53e212215f93e
+  GoogleAppMeasurement: 98b71f5e04142793729a5ef23e5b96651ff4b70f
+  GoogleUtilities: 111a012f4c3a29c9e7c954c082fafd6ee3c999c0
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
 
-PODFILE CHECKSUM: 90b95e993a50c1f73d568b2928fd105c1e3c5b0b
+PODFILE CHECKSUM: 57f492a4eb2125ae6c1efff0afb1935051312310
 
 COCOAPODS: 1.4.0

--- a/Firebase.Analytics/externals/Podfile.lock
+++ b/Firebase.Analytics/externals/Podfile.lock
@@ -1,27 +1,27 @@
 PODS:
-  - Firebase/Analytics (5.15.0):
+  - Firebase/Analytics (5.16.0):
     - Firebase/Core
-  - Firebase/Core (5.15.0):
+  - Firebase/Core (5.16.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 5.4.0)
-  - Firebase/CoreOnly (5.15.0):
-    - FirebaseCore (= 5.1.10)
-  - FirebaseAnalytics (5.4.0):
-    - FirebaseCore (~> 5.1)
-    - FirebaseInstanceID (~> 3.3)
-    - GoogleAppMeasurement (= 5.4.0)
+    - FirebaseAnalytics (= 5.5.0)
+  - Firebase/CoreOnly (5.16.0):
+    - FirebaseCore (= 5.2.0)
+  - FirebaseAnalytics (5.5.0):
+    - FirebaseCore (~> 5.2)
+    - FirebaseInstanceID (~> 3.4)
+    - GoogleAppMeasurement (= 5.5.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
     - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
     - GoogleUtilities/NSData+zlib (~> 5.2)
     - nanopb (~> 0.3)
-  - FirebaseCore (5.1.10):
+  - FirebaseCore (5.2.0):
     - GoogleUtilities/Logger (~> 5.2)
-  - FirebaseInstanceID (3.3.0):
-    - FirebaseCore (~> 5.1)
+  - FirebaseInstanceID (3.4.0):
+    - FirebaseCore (~> 5.2)
     - GoogleUtilities/Environment (~> 5.3)
     - GoogleUtilities/UserDefaults (~> 5.3)
-  - GoogleAppMeasurement (5.4.0):
+  - GoogleAppMeasurement (5.5.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 5.2)
     - GoogleUtilities/MethodSwizzler (~> 5.2)
     - GoogleUtilities/Network (~> 5.2)
@@ -52,18 +52,18 @@ PODS:
   - nanopb/encode (0.3.901)
 
 DEPENDENCIES:
-  - Firebase/Analytics (= 5.15.0)
-  - GoogleAppMeasurement (= 5.4.0)
+  - Firebase/Analytics (= 5.16.0)
+  - GoogleAppMeasurement (= 5.5.0)
 
 SPEC CHECKSUMS:
-  Firebase: 8bb9268bff82374f2cbaaabb143e725743c316ae
-  FirebaseAnalytics: c06f9d70577d79074214700a71fd5d39de5550fb
-  FirebaseCore: 35747502d9e8c6ee217385ad04446c7c2aaf9c5c
-  FirebaseInstanceID: e2fa4cb35ef5558c200f7f0ad8a53e212215f93e
-  GoogleAppMeasurement: 98b71f5e04142793729a5ef23e5b96651ff4b70f
+  Firebase: 749a8ff4962f9d8c79dda1966de20f6f77583d67
+  FirebaseAnalytics: d35d47c03c50c73c14a7fd31463c5775843e78a9
+  FirebaseCore: ea2d1816723ef21492b8e9113303e1350db5e08c
+  FirebaseInstanceID: 97ea7a5dca9afd72c79bfcdddb7a44aa1cbb42a1
+  GoogleAppMeasurement: 621f3bc6211d5ba548debe01fafad30cf5ab6859
   GoogleUtilities: 111a012f4c3a29c9e7c954c082fafd6ee3c999c0
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
 
-PODFILE CHECKSUM: 57f492a4eb2125ae6c1efff0afb1935051312310
+PODFILE CHECKSUM: 0f9c97ef62a87887f99ff4367e72604a2a9f85a3
 
 COCOAPODS: 1.4.0

--- a/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
+++ b/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Analytics</id>
     <title>Firebase APIs Analytics iOS Library</title>
-    <version>5.4.0.0</version>
+    <version>5.5.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.3.0.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.10.0" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.4.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="5.2.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
+++ b/Firebase.Analytics/nuget/Xamarin.Firebase.iOS.Analytics.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Analytics</id>
     <title>Firebase APIs Analytics iOS Library</title>
-    <version>5.1.4.1</version>
+    <version>5.4.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,8 +15,8 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.2.1.0" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.InstanceID" version="3.3.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.10.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.Analytics/source/Firebase.Analytics/Extension.cs
+++ b/Firebase.Analytics/source/Firebase.Analytics/Extension.cs
@@ -78,7 +78,9 @@ namespace Firebase.Analytics
 		public static NSString Score { get; } = new NSString ("score");
 		public static NSString SearchTerm { get; } = new NSString ("search_term");
 		public static NSString Shipping { get; } = new NSString ("shipping");
+		[Obsolete ("Use Method property instead.")]
 		public static NSString SignUpMethod { get; } = new NSString ("sign_up_method");
+		public static NSString Method { get; } = new NSString ("method");
 		public static NSString Source { get; } = new NSString ("source");
 		public static NSString StartDate { get; } = new NSString ("start_date");
 		public static NSString Tax { get; } = new NSString ("tax");

--- a/Firebase.Analytics/source/Firebase.Analytics/Firebase.Analytics.targets
+++ b/Firebase.Analytics/source/Firebase.Analytics/Firebase.Analytics.targets
@@ -3,19 +3,15 @@
 
 	<PropertyGroup>
 		<_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
-		<_FirebaseAnalyticsItemsFolder>FAnlytcs-5.1.4</_FirebaseAnalyticsItemsFolder>
+		<_FirebaseAnalyticsItemsFolder>FAnlytcs-5.4.0</_FirebaseAnalyticsItemsFolder>
 		<_FirebaseAnalyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseAnalyticsItemsFolder)\Frameworks\</_FirebaseAnalyticsSDKBaseFolder>
-		<_GoogleAppMeasurementItemsFolder>GAppM-5.1.4</_GoogleAppMeasurementItemsFolder>
+		<_GoogleAppMeasurementItemsFolder>GAppM-5.4.0</_GoogleAppMeasurementItemsFolder>
 		<_GoogleAppMeasurementSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleAppMeasurementItemsFolder)\Frameworks\</_GoogleAppMeasurementSDKBaseFolder>
 	</PropertyGroup>
 
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseAnalyticsItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/f0e97b03de33925b/FirebaseAnalytics-5.1.2.tar.gz</Url>
-			<Kind>Tgz</Kind>
-		</XamarinBuildDownload>
-		<XamarinBuildDownload Include="$(_GoogleAppMeasurementItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/9f69ad0083134fe1/GoogleAppMeasurement-5.1.2.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/353a20141ad2a091/FirebaseAnalytics-5.4.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<NativeReference Include="$(_FirebaseAnalyticsSDKBaseFolder)FirebaseAnalytics.framework">
@@ -28,6 +24,15 @@
 			<Kind>Framework</Kind>
 			<ForceLoad>True</ForceLoad>
 		</NativeReference>
+		<NativeReference Include="$(_FirebaseAnalyticsSDKBaseFolder)FIRAnalyticsConnector.framework">
+			<Kind>Framework</Kind>
+			<ForceLoad>True</ForceLoad>
+		</NativeReference>
+		
+		<XamarinBuildDownload Include="$(_GoogleAppMeasurementItemsFolder)">
+			<Url>https://dl.google.com/dl/cpdc/cfb6b1a7b6c44ed0/GoogleAppMeasurement-5.4.0.tar.gz</Url>
+			<Kind>Tgz</Kind>
+		</XamarinBuildDownload>
 		<NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurement.framework">
 			<Kind>Framework</Kind>
 			<ForceLoad>True</ForceLoad>

--- a/Firebase.Analytics/source/Firebase.Analytics/Firebase.Analytics.targets
+++ b/Firebase.Analytics/source/Firebase.Analytics/Firebase.Analytics.targets
@@ -3,15 +3,15 @@
 
 	<PropertyGroup>
 		<_FirebaseAnalyticsAssemblyName>Firebase.Analytics, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseAnalyticsAssemblyName>
-		<_FirebaseAnalyticsItemsFolder>FAnlytcs-5.4.0</_FirebaseAnalyticsItemsFolder>
+		<_FirebaseAnalyticsItemsFolder>FAnlytcs-5.5.0</_FirebaseAnalyticsItemsFolder>
 		<_FirebaseAnalyticsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseAnalyticsItemsFolder)\Frameworks\</_FirebaseAnalyticsSDKBaseFolder>
-		<_GoogleAppMeasurementItemsFolder>GAppM-5.4.0</_GoogleAppMeasurementItemsFolder>
+		<_GoogleAppMeasurementItemsFolder>GAppM-5.5.0</_GoogleAppMeasurementItemsFolder>
 		<_GoogleAppMeasurementSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleAppMeasurementItemsFolder)\Frameworks\</_GoogleAppMeasurementSDKBaseFolder>
 	</PropertyGroup>
 
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseAnalyticsItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/353a20141ad2a091/FirebaseAnalytics-5.4.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/5b53263819f02844/FirebaseAnalytics-5.5.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<NativeReference Include="$(_FirebaseAnalyticsSDKBaseFolder)FirebaseAnalytics.framework">
@@ -30,7 +30,7 @@
 		</NativeReference>
 		
 		<XamarinBuildDownload Include="$(_GoogleAppMeasurementItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/cfb6b1a7b6c44ed0/GoogleAppMeasurement-5.4.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/904e1335aa1a48c6/GoogleAppMeasurement-5.5.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<NativeReference Include="$(_GoogleAppMeasurementSDKBaseFolder)GoogleAppMeasurement.framework">

--- a/Firebase.Analytics/source/Firebase.Analytics/Properties/AssemblyInfo.cs
+++ b/Firebase.Analytics/source/Firebase.Analytics/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("5.4.0.0")]
+[assembly: AssemblyFileVersion ("5.5.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Firebase.Analytics/source/Firebase.Analytics/Properties/AssemblyInfo.cs
+++ b/Firebase.Analytics/source/Firebase.Analytics/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using Foundation;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("")]
 [assembly: AssemblyProduct ("")]
-[assembly: AssemblyCopyright ("Microsoft")]
+[assembly: AssemblyCopyright ("© Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("5.1.4.1")]
+[assembly: AssemblyFileVersion ("5.4.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Firebase.Core/externals/Podfile
+++ b/Firebase.Core/externals/Podfile
@@ -3,12 +3,12 @@ Check if main version or subversion number has changed.
 If yes, please, update Podfile file if needed.
 
 In Firebase.Core binding project, you can find the Native Reference of:
-* Firebase (5.13.0)
+* Firebase (5.15.0)
 * FirebaseAuthInterop (1.0.0)
-* FirebaseCore (5.1.8)
+* FirebaseCore (5.1.10)
 * GTMSessionFetcher (1.2.1)
 * GoogleToolboxForMac (2.1.4)
-* GoogleUtilities (5.3.6)
+* GoogleUtilities (5.3.7)
 * GoogleAPIClientForREST (1.3.7)
 * Protobuf (3.6.1)
 * leveldb-library (1.20)
@@ -21,7 +21,7 @@ platform :ios, '8.0'
 install! 'cocoapods', :integrate_targets => false
 use_frameworks!
 
-$GOOGLE_UTILITIES_VERSION = '5.3.6'
+$GOOGLE_UTILITIES_VERSION = '5.3.7'
 $GOOGLE_TOOLBOX_FOR_MAC_VERSION = '2.1.4'
 $GOOGLE_API_CLIENT_FOR_REST_VERSION = '1.3.7'
 $NANOPB_VERSION = '0.3.8'
@@ -31,7 +31,7 @@ $LEVELDB_LIBRARY_VERSION = '1.20.0'
 $FIREBASE_AUTH_INTEROP_VERSION = '1.0.0'
 
 target 'FirebaseCore' do
-	pod 'Firebase/CoreOnly', '5.13.0'
+	pod 'Firebase/CoreOnly', '5.15.0'
 	pod 'GoogleUtilities/AppDelegateSwizzler', $GOOGLE_UTILITIES_VERSION
 	pod 'GoogleUtilities/Environment', $GOOGLE_UTILITIES_VERSION
 	pod 'GoogleUtilities/ISASwizzler', $GOOGLE_UTILITIES_VERSION

--- a/Firebase.Core/externals/Podfile
+++ b/Firebase.Core/externals/Podfile
@@ -3,9 +3,9 @@ Check if main version or subversion number has changed.
 If yes, please, update Podfile file if needed.
 
 In Firebase.Core binding project, you can find the Native Reference of:
-* Firebase (5.15.0)
+* Firebase (5.16.0)
 * FirebaseAuthInterop (1.0.0)
-* FirebaseCore (5.1.10)
+* FirebaseCore (5.2.0)
 * GTMSessionFetcher (1.2.1)
 * GoogleToolboxForMac (2.1.4)
 * GoogleUtilities (5.3.7)
@@ -31,7 +31,7 @@ $LEVELDB_LIBRARY_VERSION = '1.20.0'
 $FIREBASE_AUTH_INTEROP_VERSION = '1.0.0'
 
 target 'FirebaseCore' do
-	pod 'Firebase/CoreOnly', '5.15.0'
+	pod 'Firebase/CoreOnly', '5.16.0'
 	pod 'GoogleUtilities/AppDelegateSwizzler', $GOOGLE_UTILITIES_VERSION
 	pod 'GoogleUtilities/Environment', $GOOGLE_UTILITIES_VERSION
 	pod 'GoogleUtilities/ISASwizzler', $GOOGLE_UTILITIES_VERSION

--- a/Firebase.Core/externals/Podfile
+++ b/Firebase.Core/externals/Podfile
@@ -12,7 +12,7 @@ In Firebase.Core binding project, you can find the Native Reference of:
 * GoogleAPIClientForREST (1.3.7)
 * Protobuf (3.6.1)
 * leveldb-library (1.20)
-* nanopb (0.3.8)
+* nanopb (0.3.901)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -24,7 +24,7 @@ use_frameworks!
 $GOOGLE_UTILITIES_VERSION = '5.3.7'
 $GOOGLE_TOOLBOX_FOR_MAC_VERSION = '2.1.4'
 $GOOGLE_API_CLIENT_FOR_REST_VERSION = '1.3.7'
-$NANOPB_VERSION = '0.3.8'
+$NANOPB_VERSION = '0.3.901'
 $GTM_SESSION_FETCHER = '1.2.1'
 $PROTOBUF_VERSION = '3.6.1'
 $LEVELDB_LIBRARY_VERSION = '1.20.0'

--- a/Firebase.Core/externals/Podfile.lock
+++ b/Firebase.Core/externals/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Firebase/CoreOnly (5.13.0):
-    - FirebaseCore (= 5.1.8)
+  - Firebase/CoreOnly (5.15.0):
+    - FirebaseCore (= 5.1.10)
   - FirebaseAuthInterop (1.0.0)
-  - FirebaseCore (5.1.8):
+  - FirebaseCore (5.1.10):
     - GoogleUtilities/Logger (~> 5.2)
   - GoogleAPIClientForREST (1.3.7):
     - GoogleAPIClientForREST/Core (= 1.3.7)
@@ -33,24 +33,24 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.1.4)
     - GoogleToolboxForMac/NSDictionary+URLArguments (= 2.1.4)
     - GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)
-  - GoogleUtilities/AppDelegateSwizzler (5.3.6):
+  - GoogleUtilities/AppDelegateSwizzler (5.3.7):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (5.3.6)
-  - GoogleUtilities/ISASwizzler (5.3.6)
-  - GoogleUtilities/Logger (5.3.6):
+  - GoogleUtilities/Environment (5.3.7)
+  - GoogleUtilities/ISASwizzler (5.3.7)
+  - GoogleUtilities/Logger (5.3.7):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (5.3.6):
+  - GoogleUtilities/MethodSwizzler (5.3.7):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (5.3.6):
+  - GoogleUtilities/Network (5.3.7):
     - GoogleUtilities/Logger
     - GoogleUtilities/NSData+zlib
     - GoogleUtilities/Reachability
-  - GoogleUtilities/NSData+zlib (5.3.6)
-  - GoogleUtilities/Reachability (5.3.6):
+  - GoogleUtilities/NSData+zlib (5.3.7)
+  - GoogleUtilities/Reachability (5.3.7):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (5.3.6):
+  - GoogleUtilities/UserDefaults (5.3.7):
     - GoogleUtilities/Logger
   - GTMSessionFetcher (1.2.1):
     - GTMSessionFetcher/Full (= 1.2.1)
@@ -66,7 +66,7 @@ PODS:
   - Protobuf (3.6.1)
 
 DEPENDENCIES:
-  - Firebase/CoreOnly (= 5.13.0)
+  - Firebase/CoreOnly (= 5.15.0)
   - FirebaseAuthInterop (= 1.0.0)
   - GoogleAPIClientForREST (= 1.3.7)
   - GoogleAPIClientForREST/Vision (= 1.3.7)
@@ -75,32 +75,32 @@ DEPENDENCIES:
   - GoogleToolboxForMac/NSDictionary+URLArguments (= 2.1.4)
   - GoogleToolboxForMac/StringEncoding (= 2.1.4)
   - GoogleToolboxForMac/URLBuilder (= 2.1.4)
-  - GoogleUtilities/AppDelegateSwizzler (= 5.3.6)
-  - GoogleUtilities/Environment (= 5.3.6)
-  - GoogleUtilities/ISASwizzler (= 5.3.6)
-  - GoogleUtilities/Logger (= 5.3.6)
-  - GoogleUtilities/MethodSwizzler (= 5.3.6)
-  - GoogleUtilities/Network (= 5.3.6)
-  - GoogleUtilities/NSData+zlib (= 5.3.6)
-  - GoogleUtilities/Reachability (= 5.3.6)
-  - GoogleUtilities/UserDefaults (= 5.3.6)
+  - GoogleUtilities/AppDelegateSwizzler (= 5.3.7)
+  - GoogleUtilities/Environment (= 5.3.7)
+  - GoogleUtilities/ISASwizzler (= 5.3.7)
+  - GoogleUtilities/Logger (= 5.3.7)
+  - GoogleUtilities/MethodSwizzler (= 5.3.7)
+  - GoogleUtilities/Network (= 5.3.7)
+  - GoogleUtilities/NSData+zlib (= 5.3.7)
+  - GoogleUtilities/Reachability (= 5.3.7)
+  - GoogleUtilities/UserDefaults (= 5.3.7)
   - GTMSessionFetcher/Full (= 1.2.1)
   - leveldb-library (= 1.20.0)
   - nanopb (= 0.3.8)
   - Protobuf (= 3.6.1)
 
 SPEC CHECKSUMS:
-  Firebase: 6df9a6114bc9f106a98fe83d5438d4d9833c2019
+  Firebase: 8bb9268bff82374f2cbaaabb143e725743c316ae
   FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
-  FirebaseCore: fba2bfaa691c49028309b92e4dd37cc4b5512fbe
+  FirebaseCore: 35747502d9e8c6ee217385ad04446c7c2aaf9c5c
   GoogleAPIClientForREST: 825503f12cb5824601cf526cf06d81a1cea4afd9
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
-  GoogleUtilities: 95996bea7c7d9b8fb811b7507669a4a8762f80c7
+  GoogleUtilities: 111a012f4c3a29c9e7c954c082fafd6ee3c999c0
   GTMSessionFetcher: 32aeca0aa144acea523e1c8e053089dec2cb98ca
   leveldb-library: 08cba283675b7ed2d99629a4bc5fd052cd2bb6a5
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
   Protobuf: 1eb9700044745f00181c136ef21b8ff3ad5a0fd5
 
-PODFILE CHECKSUM: cb1139757a49baa3cd92cfb2fec181cb7a299306
+PODFILE CHECKSUM: e81052748d15e47768d7761b14e3a987f4abf7b2
 
 COCOAPODS: 1.4.0

--- a/Firebase.Core/externals/Podfile.lock
+++ b/Firebase.Core/externals/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Firebase/CoreOnly (5.15.0):
-    - FirebaseCore (= 5.1.10)
+  - Firebase/CoreOnly (5.16.0):
+    - FirebaseCore (= 5.2.0)
   - FirebaseAuthInterop (1.0.0)
-  - FirebaseCore (5.1.10):
+  - FirebaseCore (5.2.0):
     - GoogleUtilities/Logger (~> 5.2)
   - GoogleAPIClientForREST (1.3.7):
     - GoogleAPIClientForREST/Core (= 1.3.7)
@@ -58,15 +58,15 @@ PODS:
   - GTMSessionFetcher/Full (1.2.1):
     - GTMSessionFetcher/Core (= 1.2.1)
   - leveldb-library (1.20)
-  - nanopb (0.3.8):
-    - nanopb/decode (= 0.3.8)
-    - nanopb/encode (= 0.3.8)
-  - nanopb/decode (0.3.8)
-  - nanopb/encode (0.3.8)
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
   - Protobuf (3.6.1)
 
 DEPENDENCIES:
-  - Firebase/CoreOnly (= 5.15.0)
+  - Firebase/CoreOnly (= 5.16.0)
   - FirebaseAuthInterop (= 1.0.0)
   - GoogleAPIClientForREST (= 1.3.7)
   - GoogleAPIClientForREST/Vision (= 1.3.7)
@@ -86,21 +86,21 @@ DEPENDENCIES:
   - GoogleUtilities/UserDefaults (= 5.3.7)
   - GTMSessionFetcher/Full (= 1.2.1)
   - leveldb-library (= 1.20.0)
-  - nanopb (= 0.3.8)
+  - nanopb (= 0.3.901)
   - Protobuf (= 3.6.1)
 
 SPEC CHECKSUMS:
-  Firebase: 8bb9268bff82374f2cbaaabb143e725743c316ae
+  Firebase: 749a8ff4962f9d8c79dda1966de20f6f77583d67
   FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
-  FirebaseCore: 35747502d9e8c6ee217385ad04446c7c2aaf9c5c
+  FirebaseCore: ea2d1816723ef21492b8e9113303e1350db5e08c
   GoogleAPIClientForREST: 825503f12cb5824601cf526cf06d81a1cea4afd9
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   GoogleUtilities: 111a012f4c3a29c9e7c954c082fafd6ee3c999c0
   GTMSessionFetcher: 32aeca0aa144acea523e1c8e053089dec2cb98ca
   leveldb-library: 08cba283675b7ed2d99629a4bc5fd052cd2bb6a5
-  nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
   Protobuf: 1eb9700044745f00181c136ef21b8ff3ad5a0fd5
 
-PODFILE CHECKSUM: e81052748d15e47768d7761b14e3a987f4abf7b2
+PODFILE CHECKSUM: 73db5c3c5383276b6c371872dd01da05e1ff39cb
 
 COCOAPODS: 1.4.0

--- a/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
+++ b/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Core</id>
     <title>Firebase APIs Core iOS Library</title>
-    <version>5.1.10.0</version>
+    <version>5.2.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
+++ b/Firebase.Core/nuget/Xamarin.Firebase.iOS.Core.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.Core</id>
     <title>Firebase APIs Core iOS Library</title>
-    <version>5.1.8.0</version>
+    <version>5.1.10.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Firebase.Core/source/Firebase.Core/Properties/AssemblyInfo.cs
+++ b/Firebase.Core/source/Firebase.Core/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("5.1.10.0")]
+[assembly: AssemblyFileVersion ("5.2.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Firebase.Core/source/Firebase.Core/Properties/AssemblyInfo.cs
+++ b/Firebase.Core/source/Firebase.Core/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using Foundation;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("")]
 [assembly: AssemblyProduct ("")]
-[assembly: AssemblyCopyright ("Microsoft")]
+[assembly: AssemblyCopyright ("© Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("5.1.3.0")]
+[assembly: AssemblyFileVersion ("5.1.10.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Firebase.InstanceID/externals/Podfile
+++ b/Firebase.InstanceID/externals/Podfile
@@ -1,19 +1,19 @@
 =begin
 Last run FirebaseInstanceID installed:
-* FirebaseCore (5.1.8)
-* FirebaseInstanceID (3.3.0)
-* GoogleUtilities (5.3.6)
+* FirebaseCore (5.2.0)
+* FirebaseInstanceID (3.4.0)
+* GoogleUtilities (5.3.7)
 
 Check if main version or subversion number has changed. 
 If yes, please, update *.targets file located in binding 
 project, also, update Podfile file if needed.
 
 In Firebase.InstanceID binding project, you can find the .targets file of:
-* FirebaseInstanceID (3.3.0)
+* FirebaseInstanceID (3.4.0)
 
 In Firebase.Core binding project, you can find the Native Reference of:
-* FirebaseCore (5.1.8)
-* GoogleUtilities (5.3.6)
+* FirebaseCore (5.2.0)
+* GoogleUtilities (5.3.7)
 =end
 
 source 'https://github.com/CocoaPods/Specs.git'
@@ -22,5 +22,5 @@ platform :ios, '8.0'
 install! 'cocoapods', :integrate_targets => false
 
 target 'FirebaseInstanceID' do
-	pod 'FirebaseInstanceID', '3.3.0'
+	pod 'FirebaseInstanceID', '3.4.0'
 end

--- a/Firebase.InstanceID/externals/Podfile.lock
+++ b/Firebase.InstanceID/externals/Podfile.lock
@@ -1,24 +1,24 @@
 PODS:
-  - FirebaseCore (5.1.8):
+  - FirebaseCore (5.2.0):
     - GoogleUtilities/Logger (~> 5.2)
-  - FirebaseInstanceID (3.3.0):
-    - FirebaseCore (~> 5.1)
+  - FirebaseInstanceID (3.4.0):
+    - FirebaseCore (~> 5.2)
     - GoogleUtilities/Environment (~> 5.3)
     - GoogleUtilities/UserDefaults (~> 5.3)
-  - GoogleUtilities/Environment (5.3.6)
-  - GoogleUtilities/Logger (5.3.6):
+  - GoogleUtilities/Environment (5.3.7)
+  - GoogleUtilities/Logger (5.3.7):
     - GoogleUtilities/Environment
-  - GoogleUtilities/UserDefaults (5.3.6):
+  - GoogleUtilities/UserDefaults (5.3.7):
     - GoogleUtilities/Logger
 
 DEPENDENCIES:
-  - FirebaseInstanceID (= 3.3.0)
+  - FirebaseInstanceID (= 3.4.0)
 
 SPEC CHECKSUMS:
-  FirebaseCore: fba2bfaa691c49028309b92e4dd37cc4b5512fbe
-  FirebaseInstanceID: e2fa4cb35ef5558c200f7f0ad8a53e212215f93e
-  GoogleUtilities: 95996bea7c7d9b8fb811b7507669a4a8762f80c7
+  FirebaseCore: ea2d1816723ef21492b8e9113303e1350db5e08c
+  FirebaseInstanceID: 97ea7a5dca9afd72c79bfcdddb7a44aa1cbb42a1
+  GoogleUtilities: 111a012f4c3a29c9e7c954c082fafd6ee3c999c0
 
-PODFILE CHECKSUM: c0011280098d41d97c779e4b73500dc1849f3fbe
+PODFILE CHECKSUM: 02f4fdfce91b4067b6399dae47bfd3d5ada91953
 
 COCOAPODS: 1.4.0

--- a/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
+++ b/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.InstanceID</id>
     <title>Firebase APIs Instance ID iOS Library</title>
-    <version>3.3.0.0</version>
+    <version>3.3.0.1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.3.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.10.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
+++ b/Firebase.InstanceID/nuget/Xamarin.Firebase.iOS.InstanceID.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.InstanceID</id>
     <title>Firebase APIs Instance ID iOS Library</title>
-    <version>3.3.0.1</version>
+    <version>3.4.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.10.0" />
+        <dependency id="Xamarin.Firebase.iOS.Core" version="5.2.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/Firebase.InstanceID/source/Firebase.InstanceID/Firebase.InstanceID.targets
+++ b/Firebase.InstanceID/source/Firebase.InstanceID/Firebase.InstanceID.targets
@@ -2,12 +2,12 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_FirebaseInstanceIDAssemblyName>Firebase.InstanceID, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_FirebaseInstanceIDAssemblyName>
-		<_FirebaseInstanceIDItemsFolder>FInstncID-3.3.0</_FirebaseInstanceIDItemsFolder>
+		<_FirebaseInstanceIDItemsFolder>FInstncID-3.4.0</_FirebaseInstanceIDItemsFolder>
 		<_FirebaseInstanceIDSDKBaseFolder>$(XamarinBuildDownloadDir)$(_FirebaseInstanceIDItemsFolder)\Frameworks\</_FirebaseInstanceIDSDKBaseFolder>
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_FirebaseInstanceIDItemsFolder)">
-			<Url>https://dl.google.com/dl/cpdc/85e39daa6262cf56/FirebaseInstanceID-3.3.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/cd1d9b33d9b1540a/FirebaseInstanceID-3.4.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<NativeReference Include="$(_FirebaseInstanceIDSDKBaseFolder)FirebaseInstanceID.framework">

--- a/Firebase.InstanceID/source/Firebase.InstanceID/Properties/AssemblyInfo.cs
+++ b/Firebase.InstanceID/source/Firebase.InstanceID/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using Foundation;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("")]
 [assembly: AssemblyProduct ("")]
-[assembly: AssemblyCopyright ("Microsoft")]
+[assembly: AssemblyCopyright ("© Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("3.2.1.0")]
+[assembly: AssemblyFileVersion ("3.3.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Firebase.InstanceID/source/Firebase.InstanceID/Properties/AssemblyInfo.cs
+++ b/Firebase.InstanceID/source/Firebase.InstanceID/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("3.3.0.0")]
+[assembly: AssemblyFileVersion ("3.4.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/Firebase.MLKit/component/component.yaml
+++ b/Firebase.MLKit/component/component.yaml
@@ -1,4 +1,4 @@
-version: 0.13.0.0
+version: 0.13.0.1
 name: Firebase MLKit for iOS
 id: firebaseiosmlkit
 publisher: Xamarin Inc.
@@ -17,7 +17,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Firebase.iOS.MLKit, Version=0.13.0.0
+  - Xamarin.Firebase.iOS.MLKit, Version=0.13.0.1
 samples:
 - name: MLKit Sample
   path: ../samples/MLKitSample/MLKitSample.sln

--- a/Firebase.MLKit/nuget/Xamarin.Firebase.iOS.MLKit.nuspec
+++ b/Firebase.MLKit/nuget/Xamarin.Firebase.iOS.MLKit.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Firebase.iOS.MLKit</id>
     <title>Firebase APIs MLKit iOS Library</title>
-    <version>0.13.0.0</version>
+    <version>0.13.0.1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -15,7 +15,7 @@
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />
-        <dependency id="Xamarin.Firebase.MLKit.Common" version="0.13.0.0" />
+        <dependency id="Xamarin.Firebase.iOS.MLKit.Common" version="0.13.0.0" />
         <dependency id="Xamarin.Firebase.iOS.Core" version="5.1.8.0" />
       </group>
     </dependencies>

--- a/Google.MobileAds/build.cake
+++ b/Google.MobileAds/build.cake
@@ -19,7 +19,10 @@ buildSpec = new BuildSpec () {
 	},
 
 	Samples = new ISolutionBuilder [] {
-		new IOSSolutionBuilder { SolutionPath = "./samples/MobileAdsExample/MobileAdsExample.sln", Configuration = "Release", BuildsOn = BuildPlatforms.Mac }, 
+		new IOSSolutionBuilder { SolutionPath = "./samples/AdMobSample/AdMobSample.sln", Configuration = "Release", BuildsOn = BuildPlatforms.Mac,
+		Properties = new Dictionary<string, List<string>> {
+			{ "MtouchArch", new List<string> { "ARM64" } }
+		} },
 	},
 
 	NuGets = new [] {

--- a/Google.MobileAds/component/component.yaml
+++ b/Google.MobileAds/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.32.0.0
+version: 7.37.0.0
 name: Google Mobile Ads for iOS
 id: googleiosmobileads
 publisher: Xamarin Inc
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.MobileAds, Version=7.32.0.0
+  - Xamarin.Google.iOS.MobileAds, Version=7.37.0.0
 samples:
 - name: Google Mobile Ads AdMob Sample
   path: ../samples/MobileAdsExample/MobileAdsExample.sln

--- a/Google.MobileAds/component/component.yaml
+++ b/Google.MobileAds/component/component.yaml
@@ -6,8 +6,8 @@ publisher-url: https://xamarin.com
 src-url: https://github.com/xamarin/GoogleApisForiOSComponents/tree/master/Google.MobileAds
 summary: Connect with advertisers and show relevant ads in your app. Users click on ads, you make money.
 icons:
-- ../../icons/googlemobileads_128x128.png
-- ../../icons/googlemobileads_512x512.png
+- ../../icons/googleiosmobileads_128x128.png
+- ../../icons/googleiosmobileads_512x512.png
 docs-url: https://developers.google.com/admob/
 libraries:
   ios-unified:

--- a/Google.MobileAds/component/component.yaml
+++ b/Google.MobileAds/component/component.yaml
@@ -1,4 +1,4 @@
-version: 7.37.0.0
+version: 7.38.0.0
 name: Google Mobile Ads for iOS
 id: googleiosmobileads
 publisher: Xamarin Inc
@@ -15,7 +15,7 @@ libraries:
 is_shell: true
 packages:
   ios-unified:
-  - Xamarin.Google.iOS.MobileAds, Version=7.37.0.0
+  - Xamarin.Google.iOS.MobileAds, Version=7.38.0.0
 samples:
 - name: Google Mobile Ads AdMob Sample
   path: ../samples/MobileAdsExample/MobileAdsExample.sln

--- a/Google.MobileAds/externals/Podfile
+++ b/Google.MobileAds/externals/Podfile
@@ -5,6 +5,6 @@ install! 'cocoapods', :integrate_targets => false
 use_frameworks!
 
 target 'Google-Mobile-Ads-SDK' do
-  pod 'Google-Mobile-Ads-SDK', '7.32.0'
+  pod 'Google-Mobile-Ads-SDK', '7.37.0'
   pod 'PersonalizedAdConsent', '1.0.3'
 end

--- a/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
+++ b/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.MobileAds</id>
     <title>Google APIs Mobile Ads iOS Library</title>
-    <version>7.32.0.0</version>
+    <version>7.37.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
+++ b/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.MobileAds</id>
     <title>Google APIs Mobile Ads iOS Library</title>
-    <version>7.38.0.0</version>
+    <version>7.38.0.0-beta1</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -12,6 +12,7 @@
     <projectUrl>https://go.microsoft.com/fwlink/?linkid=865562</projectUrl>
     <licenseUrl>https://go.microsoft.com/fwlink/?linkid=865566</licenseUrl>
     <iconUrl>https://raw.githubusercontent.com/xamarin/GoogleApisForiOSComponents/master/icons/googleiosmobileads_128x128.png</iconUrl>
+    <releaseNotes>This package has an issue with armv7 arch due missing symbols, which may cause not to work properly on some devices. This issue has been reported to Google.</releaseNotes>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.Build.Download" version="0.4.11" />

--- a/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
+++ b/Google.MobileAds/nuget/Xamarin.Google.iOS.MobileAds.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>Xamarin.Google.iOS.MobileAds</id>
     <title>Google APIs Mobile Ads iOS Library</title>
-    <version>7.37.0.0</version>
+    <version>7.38.0.0</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>

--- a/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
+++ b/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
@@ -467,6 +467,14 @@ namespace Google.MobileAds {
 
 	}
 
+	// @interface GADMediaContent : NSObject
+	[BaseType (typeof (NSObject), Name = "GADMediaContent")]
+	interface MediaContent {
+		// @property(nonatomic, readonly) CGFloat aspectRatio;
+		[Export ("aspectRatio")]
+		nfloat AspectRatio { get; }
+	}
+
 	[DisableDefaultCtor]
 	[BaseType (typeof (NSObject), Name = "GADRequest")]
 	interface Request : INSCopying {
@@ -901,6 +909,10 @@ namespace Google.MobileAds {
 		[NullAllowed]
 		[Export ("muteThisAdReasons")]
 		MuteThisAdReason [] MuteThisAdReasons { get; }
+
+		// @property(nonatomic, readonly, nonnull) GADMediaContent *mediaContent;
+		[Export ("mediaContent")]
+		MediaContent MediaContent { get; }
 
 		// -(void)registerAdView:(UIView * _Nonnull)adView clickableAssetViews:(NSDictionary<GADUnifiedNativeAssetIdentifier,UIView *> * _Nonnull)clickableAssetViews nonclickableAssetViews:(NSDictionary<GADUnifiedNativeAssetIdentifier,UIView *> * _Nonnull)nonclickableAssetViews;
 		[Export ("registerAdView:clickableAssetViews:nonclickableAssetViews:")]
@@ -1458,7 +1470,7 @@ namespace Google.MobileAds {
 		[Export ("price")]
 		string Price { get; }
 
-		// @property (readonly, nonatomic, strong) NSArray * images;
+		// @property (readonly, nonatomic, strong) NSArray<GADNativeAdImage *> * images;
 		[NullAllowed]
 		[Export ("images", ArgumentSemantic.Strong)]
 		NativeAdImage [] Images { get; }
@@ -1578,7 +1590,7 @@ namespace Google.MobileAds {
 		[Export ("body")]
 		string Body { get; }
 
-		// @property (readonly, copy, nonatomic) NSArray * images;
+		// @property (readonly, copy, nonatomic) NSArray<GADNativeAdImage *> * images;
 		[NullAllowed]
 		[Export ("images", ArgumentSemantic.Copy)]
 		NativeAdImage [] Images { get; }
@@ -2637,6 +2649,10 @@ namespace Google.MobileAds {
 	// @interface GADMediaView : UIView
 	[BaseType (typeof (UIView), Name = "GADMediaView")]
 	interface MediaView {
+		// @property (nonatomic, nullable) GADMediaContent* mediaContent;
+		[NullAllowed]
+		[Export ("mediaContent")]
+		MediaContent MediaContent { get; set; }
 	}
 
 	// @interface GADNativeMuteThisAdLoaderOptions : GADAdLoaderOptions

--- a/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
+++ b/Google.MobileAds/source/Google.MobileAds/ApiDefinition.cs
@@ -933,6 +933,18 @@ namespace Google.MobileAds {
 		// -(void)cancelUnconfirmedClick;
 		[Export ("cancelUnconfirmedClick")]
 		void CancelUnconfirmedClick ();
+
+		///
+		/// From UnifiedNativeAd_CustomClickGesture Category
+		///
+
+		// - (void)enableCustomClickGestures;
+		[Export ("enableCustomClickGestures")]
+		void EnableCustomClickGestures ();
+
+		// - (void)recordCustomClickGesture;
+		[Export ("recordCustomClickGesture")]
+		void RecordCustomClickGesture ();
 	}
 
 	interface IUnifiedNativeAdLoaderDelegate { }
@@ -1396,6 +1408,7 @@ namespace Google.MobileAds {
 		UIImage Image { get; }
 
 		// @property (readonly, nonatomic, strong) NSURL * imageURL;
+		[NullAllowed]
 		[Export ("imageURL", ArgumentSemantic.Copy)]
 		NSUrl ImageUrl { get; }
 

--- a/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
+++ b/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleMobileAdsAssemblyName>Google.MobileAds, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleMobileAdsAssemblyName>
-		<_GoogleMobileAdsId>FAdM-7.37.0</_GoogleMobileAdsId>
+		<_GoogleMobileAdsId>FAdM-7.38.0</_GoogleMobileAdsId>
 		<_GoogleMobileAdsConsentId>GCnsnt-1.0.3</_GoogleMobileAdsConsentId>
 		<_GoogleMobileAdsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleMobileAdsId)\Frameworks\frameworks\</_GoogleMobileAdsSDKBaseFolder>
 		<_GoogleMobileAdsConsentSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleMobileAdsConsentId)\googleads-consent-sdk-ios-1.0.3\PersonalizedAdConsent\PersonalizedAdConsent\</_GoogleMobileAdsConsentSDKBaseFolder>
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_GoogleMobileAdsId)">
-			<Url>https://dl.google.com/dl/cpdc/ff3cd867cd84c0eb/Google-Mobile-Ads-SDK-7.37.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/b8745d3de2e626d7/Google-Mobile-Ads-SDK-7.38.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
 		</XamarinBuildDownload>
 		<NativeReference Include="$(_GoogleMobileAdsSDKBaseFolder)GoogleMobileAds.framework">

--- a/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
+++ b/Google.MobileAds/source/Google.MobileAds/Google.MobileAds.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<_GoogleMobileAdsAssemblyName>Google.MobileAds, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null</_GoogleMobileAdsAssemblyName>
-		<_GoogleMobileAdsId>FAdM-7.32.0</_GoogleMobileAdsId>
+		<_GoogleMobileAdsId>FAdM-7.37.0</_GoogleMobileAdsId>
 		<_GoogleMobileAdsConsentId>GCnsnt-1.0.3</_GoogleMobileAdsConsentId>
 		<_GoogleMobileAdsSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleMobileAdsId)\Frameworks\frameworks\</_GoogleMobileAdsSDKBaseFolder>
 		<_GoogleMobileAdsConsentSDKBaseFolder>$(XamarinBuildDownloadDir)$(_GoogleMobileAdsConsentId)\googleads-consent-sdk-ios-1.0.3\PersonalizedAdConsent\PersonalizedAdConsent\</_GoogleMobileAdsConsentSDKBaseFolder>
@@ -11,20 +11,21 @@
 	</PropertyGroup>
 	<ItemGroup Condition="('$(OutputType)'!='Library' OR '$(IsAppExtension)'=='True')">
 		<XamarinBuildDownload Include="$(_GoogleMobileAdsId)">
-			<Url>https://dl.google.com/dl/cpdc/df9aab423b363958/Google-Mobile-Ads-SDK-7.32.0.tar.gz</Url>
+			<Url>https://dl.google.com/dl/cpdc/ff3cd867cd84c0eb/Google-Mobile-Ads-SDK-7.37.0.tar.gz</Url>
 			<Kind>Tgz</Kind>
-		</XamarinBuildDownload>
-		<XamarinBuildDownload Include="$(_GoogleMobileAdsConsentId)">
-			<Url>https://github.com/googleads/googleads-consent-sdk-ios/archive/v1.0.3.zip</Url>
-			<Kind>Zip</Kind>
 		</XamarinBuildDownload>
 		<NativeReference Include="$(_GoogleMobileAdsSDKBaseFolder)GoogleMobileAds.framework">
 			<Kind>Framework</Kind>
 			<ForceLoad>True</ForceLoad>
-			<LinkerFlags>-ObjC</LinkerFlags>
+			<LinkerFlags>-ObjC -lz -lsqlite3</LinkerFlags>
 			<Frameworks>AudioToolbox AVFoundation CFNetwork CoreGraphics CoreMedia CoreMotion CoreTelephony CoreVideo GLKit MediaPlayer MessageUI MobileCoreServices OpenGLES QuartzCore Security StoreKit SystemConfiguration</Frameworks>
 			<WeakFrameworks>AdSupport JavaScriptCore SafariServices WebKit</WeakFrameworks>
 		</NativeReference>
+		
+		<XamarinBuildDownload Include="$(_GoogleMobileAdsConsentId)">
+			<Url>https://github.com/googleads/googleads-consent-sdk-ios/archive/v1.0.3.zip</Url>
+			<Kind>Zip</Kind>
+		</XamarinBuildDownload>
 		<GoogleMobileAdsCopyResources Include="$(_GoogleMobileAdsConsentSDKBaseFolder)PersonalizedAdConsent.bundle\consentform.html" />
 	</ItemGroup>
 

--- a/Google.MobileAds/source/Google.MobileAds/Properties/AssemblyInfo.cs
+++ b/Google.MobileAds/source/Google.MobileAds/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using Foundation;
 [assembly: AssemblyConfiguration ("")]
 [assembly: AssemblyCompany ("")]
 [assembly: AssemblyProduct ("")]
-[assembly: AssemblyCopyright ("Microsoft")]
+[assembly: AssemblyCopyright ("© Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark ("")]
 [assembly: AssemblyCulture ("")]
 
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("7.32.0.0")]
+[assembly: AssemblyFileVersion ("7.37.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/Google.MobileAds/source/Google.MobileAds/Properties/AssemblyInfo.cs
+++ b/Google.MobileAds/source/Google.MobileAds/Properties/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using Foundation;
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
 [assembly: AssemblyVersion ("1.0.0.0")]
-[assembly: AssemblyFileVersion ("7.37.0.0")]
+[assembly: AssemblyFileVersion ("7.38.0.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | [Xamarin.Firebase.iOS.DynamicLinks][F.DynamicLinks.Name]                     | [3.0.2.0][F.DynamicLinks.Package]            |
 | [Xamarin.Firebase.iOS.InstanceID][F.InstanceID.Name]                         | [3.3.0.1][F.InstanceID.Package]              |
 | [Xamarin.Firebase.iOS.Invites][F.Invites.Name]                               | [3.0.1.1][F.Invites.Package]                 |
-| [Xamarin.Firebase.iOS.MLKit][F.MLKit.Name]                                   | [0.13.0.0][F.MLKit.Package]                  |
+| [Xamarin.Firebase.iOS.MLKit][F.MLKit.Name]                                   | [0.13.0.1][F.MLKit.Package]                  |
 | [Xamarin.Firebase.iOS.MLKit.Common][F.MLKit.Common.Name]                     | [0.13.0.0][F.MLKit.Common.Package]           |
 | [Xamarin.Firebase.iOS.MLKit.ModelInterpreter][F.MLKit.ModelInterpreter.Name] | [0.13.0.0][F.MLKit.ModelInterpreter.Package] |
 | [Xamarin.Firebase.iOS.PerformanceMonitoring][F.PerformanceMonitoring.Name]   | [2.1.2.0][F.PerformanceMonitoring.Package]   |
@@ -61,7 +61,7 @@ Here's a table that shows in which global version is located each component of F
 | Firebase Dynamic Links           | **3.0.2.0**       | **5.8.1**      |
 | Firebase Instance ID             | **3.3.0.1**       | **5.15.0**     |
 | Firebase Invites                 | **3.0.1.1**       | **5.8.1**      |
-| Firebase MLKit                   | **0.13.0.0**      | **5.13.0*      |
+| Firebase MLKit                   | **0.13.0.1**      | **5.13.0*      |
 | Firebase MLKit Common            | **0.13.0.0**      | **5.13.0*      |
 | Firebase MLKit Model Interpreter | **0.13.0.0**      | **5.13.0*      |
 | Firebase Performance Monitoring  | **2.1.2.0**       | **5.8.1**      |

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | [Xamarin.Firebase.iOS.Crashlytics][F.Crashlytics.Name]                       | [3.10.3.1][F.Crashlytics.Package]            |
 | [Xamarin.Firebase.iOS.Database][F.Database.Name]                             | [5.0.3.0][F.Database.Package]                |
 | [Xamarin.Firebase.iOS.DynamicLinks][F.DynamicLinks.Name]                     | [3.0.2.0][F.DynamicLinks.Package]            |
-| [Xamarin.Firebase.iOS.InstanceID][F.InstanceID.Name]                         | [3.3.0.0][F.InstanceID.Package]              |
+| [Xamarin.Firebase.iOS.InstanceID][F.InstanceID.Name]                         | [3.3.0.1][F.InstanceID.Package]              |
 | [Xamarin.Firebase.iOS.Invites][F.Invites.Name]                               | [3.0.1.1][F.Invites.Package]                 |
 | [Xamarin.Firebase.iOS.MLKit][F.MLKit.Name]                                   | [0.13.0.0][F.MLKit.Package]                  |
 | [Xamarin.Firebase.iOS.MLKit.Common][F.MLKit.Common.Name]                     | [0.13.0.0][F.MLKit.Common.Package]           |
@@ -59,7 +59,7 @@ Here's a table that shows in which global version is located each component of F
 | Firebase Core                    | **5.1.10.0**      | **5.15.0**     |
 | Firebase Database                | **5.0.3.0**       | **5.8.1**      |
 | Firebase Dynamic Links           | **3.0.2.0**       | **5.8.1**      |
-| Firebase Instance ID             | **3.3.0.0**       | **5.13.0**     |
+| Firebase Instance ID             | **3.3.0.1**       | **5.15.0**     |
 | Firebase Invites                 | **3.0.1.1**       | **5.8.1**      |
 | Firebase MLKit                   | **0.13.0.0**      | **5.13.0*      |
 | Firebase MLKit Common            | **0.13.0.0**      | **5.13.0*      |

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 |------------------------------------------------------------------------------|----------------------------------------------|
 | [Xamarin.Firebase.iOS.ABTesting][F.ABTesting.Name]                           | [2.0.0.1][F.ABTesting.Package]               |
 | [Xamarin.Firebase.iOS.AdMob][F.AdMob.Name]                                   | [7.37.0.0][F.AdMob.Package]                  |
-| [Xamarin.Firebase.iOS.Analytics][F.Analytics.Name]                           | [5.4.0.0][F.Analytics.Package]               |
+| [Xamarin.Firebase.iOS.Analytics][F.Analytics.Name]                           | [5.5.0.0][F.Analytics.Package]               |
 | [Xamarin.Firebase.iOS.Auth][F.Auth.Name]                                     | [5.0.4.1][F.Auth.Package]                    |
 | [Xamarin.Firebase.iOS.CloudFirestore][F.CloudFirestore.Name]                 | [0.13.3.0][F.CloudFirestore.Package]         |
 | [Xamarin.Firebase.iOS.CloudMessaging][F.CloudMessaging.Name]                 | [3.1.2.0][F.CloudMessaging.Package]          |
@@ -52,7 +52,7 @@ Here's a table that shows in which global version is located each component of F
 |----------------------------------|:-----------------:|:--------------:|
 | Firebase A/B Testing             | **2.0.0.1**       | **5.8.1**      |
 | Firebase AdMob                   | **7.37.0.0**      | **5.15.0**     |
-| Firebase Analytics               | **5.4.0.0**       | **5.15.0**     |
+| Firebase Analytics               | **5.5.0.0**       | **5.16.0**     |
 | Firebase Auth                    | **5.0.4.1**       | **5.8.1**      |
 | Firebase Cloud Firestore         | **0.13.3.0**      | **5.8.1**      |
 | Firebase Cloud Messaging         | **3.1.2.0**       | **5.8.1**      |

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | [Xamarin.Firebase.iOS.Crashlytics][F.Crashlytics.Name]                       | [3.10.3.1][F.Crashlytics.Package]            |
 | [Xamarin.Firebase.iOS.Database][F.Database.Name]                             | [5.0.3.0][F.Database.Package]                |
 | [Xamarin.Firebase.iOS.DynamicLinks][F.DynamicLinks.Name]                     | [3.0.2.0][F.DynamicLinks.Package]            |
-| [Xamarin.Firebase.iOS.InstanceID][F.InstanceID.Name]                         | [3.3.0.1][F.InstanceID.Package]              |
+| [Xamarin.Firebase.iOS.InstanceID][F.InstanceID.Name]                         | [3.4.0.0][F.InstanceID.Package]              |
 | [Xamarin.Firebase.iOS.Invites][F.Invites.Name]                               | [3.0.1.1][F.Invites.Package]                 |
 | [Xamarin.Firebase.iOS.MLKit][F.MLKit.Name]                                   | [0.13.0.1][F.MLKit.Package]                  |
 | [Xamarin.Firebase.iOS.MLKit.Common][F.MLKit.Common.Name]                     | [0.13.0.0][F.MLKit.Common.Package]           |
@@ -59,7 +59,7 @@ Here's a table that shows in which global version is located each component of F
 | Firebase Core                    | **5.2.0.0**       | **5.16.0**     |
 | Firebase Database                | **5.0.3.0**       | **5.8.1**      |
 | Firebase Dynamic Links           | **3.0.2.0**       | **5.8.1**      |
-| Firebase Instance ID             | **3.3.0.1**       | **5.15.0**     |
+| Firebase Instance ID             | **3.4.0.0**       | **5.16.0**     |
 | Firebase Invites                 | **3.0.1.1**       | **5.8.1**      |
 | Firebase MLKit                   | **0.13.0.1**      | **5.13.0*      |
 | Firebase MLKit Common            | **0.13.0.0**      | **5.13.0*      |

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | Package Id                                                                   | NuGet                                        |
 |------------------------------------------------------------------------------|----------------------------------------------|
 | [Xamarin.Firebase.iOS.ABTesting][F.ABTesting.Name]                           | [2.0.0.1][F.ABTesting.Package]               |
-| [Xamarin.Firebase.iOS.AdMob][F.AdMob.Name]                                   | [7.32.0.0][F.AdMob.Package]                  |
+| [Xamarin.Firebase.iOS.AdMob][F.AdMob.Name]                                   | [7.37.0.0][F.AdMob.Package]                  |
 | [Xamarin.Firebase.iOS.Analytics][F.Analytics.Name]                           | [5.4.0.0][F.Analytics.Package]               |
 | [Xamarin.Firebase.iOS.Auth][F.Auth.Name]                                     | [5.0.4.1][F.Auth.Package]                    |
 | [Xamarin.Firebase.iOS.CloudFirestore][F.CloudFirestore.Name]                 | [0.13.3.0][F.CloudFirestore.Package]         |
@@ -51,7 +51,7 @@ Here's a table that shows in which global version is located each component of F
 | Component Name                   | Component Version | Global Version |
 |----------------------------------|:-----------------:|:--------------:|
 | Firebase A/B Testing             | **2.0.0.1**       | **5.8.1**      |
-| Firebase AdMob                   | **7.32.0.0**      | **5.8.1**      |
+| Firebase AdMob                   | **7.37.0.0**      | **5.15.0**     |
 | Firebase Analytics               | **5.4.0.0**       | **5.15.0**     |
 | Firebase Auth                    | **5.0.4.1**       | **5.8.1**      |
 | Firebase Cloud Firestore         | **0.13.3.0**      | **5.8.1**      |

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | Package Id                                                                   | NuGet                                        |
 |------------------------------------------------------------------------------|----------------------------------------------|
 | [Xamarin.Firebase.iOS.ABTesting][F.ABTesting.Name]                           | [2.0.0.1][F.ABTesting.Package]               |
-| [Xamarin.Firebase.iOS.AdMob][F.AdMob.Name]                                   | [7.37.0.0][F.AdMob.Package]                  |
+| [Xamarin.Firebase.iOS.AdMob][F.AdMob.Name]                                   | [7.38.0.0][F.AdMob.Package]                  |
 | [Xamarin.Firebase.iOS.Analytics][F.Analytics.Name]                           | [5.5.0.0][F.Analytics.Package]               |
 | [Xamarin.Firebase.iOS.Auth][F.Auth.Name]                                     | [5.0.4.1][F.Auth.Package]                    |
 | [Xamarin.Firebase.iOS.CloudFirestore][F.CloudFirestore.Name]                 | [0.13.3.0][F.CloudFirestore.Package]         |
@@ -29,7 +29,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | [Xamarin.Google.iOS.Cast][G.Cast.Name]                                       | [4.3.2.0][G.Cast.Package]                    |
 | [Xamarin.Google.iOS.InstanceID][G.InstanceID.Name]                           | [1.2.1.14][G.InstanceID.Package]             |
 | [Xamarin.Google.iOS.Maps][G.Maps.Name]                                       | [2.7.0.0][G.Maps.Package]                    |
-| [Xamarin.Google.iOS.MobileAds][G.MobileAds.Name]                             | [7.32.0.0][G.MobileAds.Package]              |
+| [Xamarin.Google.iOS.MobileAds][G.MobileAds.Name]                             | [7.38.0.0][G.MobileAds.Package]              |
 | [Xamarin.Google.iOS.Places][G.Places.Name]                                   | [2.7.0.0][G.Places.Package]                  |
 | [Xamarin.Google.iOS.PlayGames][G.PlayGames.Name]                             | [5.1.1.10][G.PlayGames.Package]              |
 | [Xamarin.Google.iOS.SignIn][G.SignIn.Name]                                   | [4.2.0.0][G.SignIn.Package]                  |
@@ -51,7 +51,7 @@ Here's a table that shows in which global version is located each component of F
 | Component Name                   | Component Version | Global Version |
 |----------------------------------|:-----------------:|:--------------:|
 | Firebase A/B Testing             | **2.0.0.1**       | **5.8.1**      |
-| Firebase AdMob                   | **7.37.0.0**      | **5.15.0**     |
+| Firebase AdMob                   | **7.38.0.0**      | **5.16.0**     |
 | Firebase Analytics               | **5.5.0.0**       | **5.16.0**     |
 | Firebase Auth                    | **5.0.4.1**       | **5.8.1**      |
 | Firebase Cloud Firestore         | **0.13.3.0**      | **5.8.1**      |

--- a/Readme.md
+++ b/Readme.md
@@ -8,11 +8,11 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 |------------------------------------------------------------------------------|----------------------------------------------|
 | [Xamarin.Firebase.iOS.ABTesting][F.ABTesting.Name]                           | [2.0.0.1][F.ABTesting.Package]               |
 | [Xamarin.Firebase.iOS.AdMob][F.AdMob.Name]                                   | [7.32.0.0][F.AdMob.Package]                  |
-| [Xamarin.Firebase.iOS.Analytics][F.Analytics.Name]                           | [5.1.4.1][F.Analytics.Package]               |
+| [Xamarin.Firebase.iOS.Analytics][F.Analytics.Name]                           | [5.4.0.0][F.Analytics.Package]               |
 | [Xamarin.Firebase.iOS.Auth][F.Auth.Name]                                     | [5.0.4.1][F.Auth.Package]                    |
 | [Xamarin.Firebase.iOS.CloudFirestore][F.CloudFirestore.Name]                 | [0.13.3.0][F.CloudFirestore.Package]         |
 | [Xamarin.Firebase.iOS.CloudMessaging][F.CloudMessaging.Name]                 | [3.1.2.0][F.CloudMessaging.Package]          |
-| [Xamarin.Firebase.iOS.Core][F.Core.Name]                                     | [5.1.10.0][F.Core.Package]                    |
+| [Xamarin.Firebase.iOS.Core][F.Core.Name]                                     | [5.1.10.0][F.Core.Package]                   |
 | [Xamarin.Firebase.iOS.Crashlytics][F.Crashlytics.Name]                       | [3.10.3.1][F.Crashlytics.Package]            |
 | [Xamarin.Firebase.iOS.Database][F.Database.Name]                             | [5.0.3.0][F.Database.Package]                |
 | [Xamarin.Firebase.iOS.DynamicLinks][F.DynamicLinks.Name]                     | [3.0.2.0][F.DynamicLinks.Package]            |
@@ -52,7 +52,7 @@ Here's a table that shows in which global version is located each component of F
 |----------------------------------|:-----------------:|:--------------:|
 | Firebase A/B Testing             | **2.0.0.1**       | **5.8.1**      |
 | Firebase AdMob                   | **7.32.0.0**      | **5.8.1**      |
-| Firebase Analytics               | **5.1.4.1**       | **5.8.1**      |
+| Firebase Analytics               | **5.4.0.0**       | **5.15.0**     |
 | Firebase Auth                    | **5.0.4.1**       | **5.8.1**      |
 | Firebase Cloud Firestore         | **0.13.3.0**      | **5.8.1**      |
 | Firebase Cloud Messaging         | **3.1.2.0**       | **5.8.1**      |

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | [Xamarin.Firebase.iOS.Auth][F.Auth.Name]                                     | [5.0.4.1][F.Auth.Package]                    |
 | [Xamarin.Firebase.iOS.CloudFirestore][F.CloudFirestore.Name]                 | [0.13.3.0][F.CloudFirestore.Package]         |
 | [Xamarin.Firebase.iOS.CloudMessaging][F.CloudMessaging.Name]                 | [3.1.2.0][F.CloudMessaging.Package]          |
-| [Xamarin.Firebase.iOS.Core][F.Core.Name]                                     | [5.1.8.0][F.Core.Package]                    |
+| [Xamarin.Firebase.iOS.Core][F.Core.Name]                                     | [5.1.10.0][F.Core.Package]                    |
 | [Xamarin.Firebase.iOS.Crashlytics][F.Crashlytics.Name]                       | [3.10.3.1][F.Crashlytics.Package]            |
 | [Xamarin.Firebase.iOS.Database][F.Database.Name]                             | [5.0.3.0][F.Database.Package]                |
 | [Xamarin.Firebase.iOS.DynamicLinks][F.DynamicLinks.Name]                     | [3.0.2.0][F.DynamicLinks.Package]            |
@@ -56,7 +56,7 @@ Here's a table that shows in which global version is located each component of F
 | Firebase Auth                    | **5.0.4.1**       | **5.8.1**      |
 | Firebase Cloud Firestore         | **0.13.3.0**      | **5.8.1**      |
 | Firebase Cloud Messaging         | **3.1.2.0**       | **5.8.1**      |
-| Firebase Core                    | **5.1.8.0**       | **5.13.0**     |
+| Firebase Core                    | **5.1.10.0**      | **5.15.0**     |
 | Firebase Database                | **5.0.3.0**       | **5.8.1**      |
 | Firebase Dynamic Links           | **3.0.2.0**       | **5.8.1**      |
 | Firebase Instance ID             | **3.3.0.0**       | **5.13.0**     |

--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@ Xamarin creates and maintains Xamarin.iOS bindings for the Google APIs for iOS L
 | [Xamarin.Firebase.iOS.Auth][F.Auth.Name]                                     | [5.0.4.1][F.Auth.Package]                    |
 | [Xamarin.Firebase.iOS.CloudFirestore][F.CloudFirestore.Name]                 | [0.13.3.0][F.CloudFirestore.Package]         |
 | [Xamarin.Firebase.iOS.CloudMessaging][F.CloudMessaging.Name]                 | [3.1.2.0][F.CloudMessaging.Package]          |
-| [Xamarin.Firebase.iOS.Core][F.Core.Name]                                     | [5.1.10.0][F.Core.Package]                   |
+| [Xamarin.Firebase.iOS.Core][F.Core.Name]                                     | [5.2.0.0][F.Core.Package]                    |
 | [Xamarin.Firebase.iOS.Crashlytics][F.Crashlytics.Name]                       | [3.10.3.1][F.Crashlytics.Package]            |
 | [Xamarin.Firebase.iOS.Database][F.Database.Name]                             | [5.0.3.0][F.Database.Package]                |
 | [Xamarin.Firebase.iOS.DynamicLinks][F.DynamicLinks.Name]                     | [3.0.2.0][F.DynamicLinks.Package]            |
@@ -56,7 +56,7 @@ Here's a table that shows in which global version is located each component of F
 | Firebase Auth                    | **5.0.4.1**       | **5.8.1**      |
 | Firebase Cloud Firestore         | **0.13.3.0**      | **5.8.1**      |
 | Firebase Cloud Messaging         | **3.1.2.0**       | **5.8.1**      |
-| Firebase Core                    | **5.1.10.0**      | **5.15.0**     |
+| Firebase Core                    | **5.2.0.0**       | **5.16.0**     |
 | Firebase Database                | **5.0.3.0**       | **5.8.1**      |
 | Firebase Dynamic Links           | **3.0.2.0**       | **5.8.1**      |
 | Firebase Instance ID             | **3.3.0.1**       | **5.15.0**     |

--- a/poco.cake
+++ b/poco.cake
@@ -97,9 +97,10 @@ public abstract class Firebase
 			get { return new [] { new Firebase.ABTesting ().Name, new Firebase.AdMob ().Name, new Firebase.Analytics ().Name, 
 					new Firebase.Auth ().Name, new Firebase.CloudFirestore ().Name, new Firebase.CloudMessaging ().Name, 
 					new Firebase.Database ().Name, new Firebase.DynamicLinks ().Name, new Firebase.InstanceID ().Name, 
-					new Firebase.Invites ().Name, new Firebase.PerformanceMonitoring ().Name, new Firebase.RemoteConfig ().Name, 
-					new Firebase.Storage ().Name, new Google.Cast ().Name, new Google.InstanceID ().Name, new Google.PlayGames ().Name, 
-					new Google.SignIn ().Name, new Google.TagManager ().Name };
+					new Firebase.Invites ().Name, new Firebase.MLKit ().Name, new Firebase.MLKit.Common ().Name, 
+					new Firebase.MLKit.ModelInterpreter ().Name, new Firebase.PerformanceMonitoring ().Name, new Firebase.RemoteConfig ().Name, 
+					new Firebase.Storage ().Name, new Google.Cast ().Name, new Google.InstanceID ().Name, 
+					new Google.PlayGames ().Name, new Google.SignIn ().Name, new Google.TagManager ().Name };
 			}
 		}
 	}
@@ -158,8 +159,8 @@ public abstract class Firebase
 		public override string [] BaseOf  { 
 			get { return new [] { new Firebase.ABTesting ().Name, new Firebase.AdMob ().Name, new Firebase.Analytics ().Name, 
 					new Firebase.CloudMessaging ().Name, new Firebase.DynamicLinks ().Name, new Firebase.Invites ().Name, 
-					new Firebase.PerformanceMonitoring ().Name, new Firebase.RemoteConfig ().Name, new Google.InstanceID ().Name, 
-					new Google.TagManager ().Name };
+					new Firebase.MLKit.ModelInterpreter ().Name, new Firebase.PerformanceMonitoring ().Name, new Firebase.RemoteConfig ().Name, 
+					new Google.InstanceID ().Name, new Google.TagManager ().Name };
 			}
 		}
 	}
@@ -171,6 +172,39 @@ public abstract class Firebase
 		}
 		public override string NuGetId { 
 			get { return "Xamarin.Firebase.iOS.Invites"; }
+		}
+	}
+
+	public class MLKit : GoogleBase
+	{
+		public override string Name  { 
+			get { return "Firebase.MLKit"; }
+		}
+		public override string NuGetId { 
+			get { return "Xamarin.Firebase.iOS.MLKit"; }
+		}
+
+		public class Common : MLKit
+		{
+			public override string Name  { 
+				get { return "Firebase.MLKit.Common"; }
+			}
+			public override string NuGetId { 
+				get { return "Xamarin.Firebase.iOS.MLKit.Common"; }
+			}
+			public override string [] BaseOf  { 
+				get { return new [] { new Firebase.MLKit ().Name, new Firebase.MLKit.ModelInterpreter ().Name }; }
+			}
+		}
+
+		public class ModelInterpreter : MLKit
+		{
+			public override string Name  { 
+				get { return "Firebase.MLKit.ModelInterpreter"; }
+			}
+			public override string NuGetId { 
+				get { return "Xamarin.Firebase.iOS.MLKit.ModelInterpreter"; }
+			}
 		}
 	}
 
@@ -349,7 +383,8 @@ public abstract class Xamarin
 							new Firebase.DynamicLinks ().Name, new Firebase.InstanceID ().Name, new Firebase.Invites ().Name, 
 							new Firebase.PerformanceMonitoring ().Name, new Firebase.RemoteConfig ().Name, new Firebase.Storage ().Name, 
 							new Google.Analytics ().Name, new Google.AppIndexing ().Name, new Google.Cast ().Name, 
-							new Google.InstanceID ().Name, new Google.Maps ().Name, new Google.MobileAds ().Name, 
+							new Google.InstanceID ().Name, new Firebase.MLKit ().Name, new Firebase.MLKit.Common ().Name, 
+							new Firebase.MLKit.ModelInterpreter ().Name, new Google.Maps ().Name, new Google.MobileAds ().Name, 
 							new Google.Places ().Name, new Google.PlayGames ().Name, new Google.SignIn ().Name, 
 							new Google.TagManager ().Name };
 				}

--- a/update.cake
+++ b/update.cake
@@ -37,6 +37,9 @@ public Dictionary<string, GoogleBase> CreateComponents ()
 	googleComponents ["Firebase.DynamicLinks"] = GetComponent<Firebase.DynamicLinks> ();
 	googleComponents ["Firebase.InstanceID"] = GetComponent<Firebase.InstanceID> ();
 	googleComponents ["Firebase.Invites"] = GetComponent<Firebase.Invites> ();
+	googleComponents ["Firebase.MLKit"] = GetComponent<Firebase.MLKit> ();
+	googleComponents ["Firebase.MLKit.Common"] = GetComponent<Firebase.MLKit.Common> ();
+	googleComponents ["Firebase.MLKit.ModelInterpreter"] = GetComponent<Firebase.MLKit.ModelInterpreter> ();
 	googleComponents ["Firebase.PerformanceMonitoring"] = GetComponent<Firebase.PerformanceMonitoring> ();
 	googleComponents ["Firebase.RemoteConfig"] = GetComponent<Firebase.RemoteConfig> ();
 	googleComponents ["Firebase.Storage"] = GetComponent<Firebase.Storage> ();


### PR DESCRIPTION
This PR contains updates for:

* Firebase Core v5.2.0
* Firebase Instance ID v3.4.0
* Firebase Analytics v5.5.0
* FIrebase AdMob v7.38.0

These components target Firebase v5.16.0