### PR TITLE
clarified "App" syntax

### DIFF
--- a/Firebase.CloudMessaging/component/GettingStarted.md
+++ b/Firebase.CloudMessaging/component/GettingStarted.md
@@ -91,7 +91,7 @@ Once you have your `GoogleService-Info.plist` file downloaded in your computer, 
 4. Add the following line of code somewhere in your app, typically in your AppDelegate's `FinishedLaunching` method (don't forget to import `Firebase.Core` namespace):
 
 ```csharp
-App.Configure ();
+Firebase.Core.App.Configure();
 ```
 
 ### Register for remote notifications


### PR DESCRIPTION
This class would overlap with the default xamarin forms `App` class name.