### PR TITLE
Fix "supermarket" missing from PlaceTypes

### DIFF
--- a/source/Google/Places/ApiDefinition.cs
+++ b/source/Google/Places/ApiDefinition.cs
@@ -20,7 +20,6 @@ namespace Google.Places
 		NSString Type { get; }
 
 		// @property (readonly, nonatomic, strong) NSArray<NSString *> * _Nonnull types;
-		[BindAs (typeof (PlaceType []))]
 		[Export ("types", ArgumentSemantic.Strong)]
 		NSString [] Types { get; }
 


### PR DESCRIPTION
Fixes #401. This is a breaking change: the type of `Google.Places.Types` is changed from `PlaceType[]` to `string[]`.

Advantages:
* Works around a bug in Google's SDK in including `supermarket` in the [supported types](https://developers.google.com/places/ios-sdk/supported_types) while not including it in [GMSPlaceType](https://developers.google.com/places/ios-sdk/reference/group___place_types).
* Adds resilience against future change to the Google SDK. If a type is added that is not known to the Xamarin wrapper, the wrapper's code will get an unexpected string, which is much easier to deal with than the getter for `Places.Types` throwing `NotSupportedException`.

Disadvantages:
* When developers update to the new NuGet package, they will get a compile error and have to change their code. This is preferable, however, to their code compiling and the system appearing to work, only to have apps mysteriously crash in the field as users search happen to search for supermarkets.

If the PR is implemented, `PlaceType` should be removed, as it is no longer uses, and the documentation should be updated to link to the [supported types](https://developers.google.com/places/ios-sdk/supported_types).