### PR TITLE
Software Bill of Materials (SBOM) manifest generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,25 @@ jobs:
       cakeExtraArgs: '--names=$(SdksNames)'
       windowsImage: ''
       xcode: '13.1'
+
+  - ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        artifactNames: ['nuget']
+        packageName: 'Xamarin Google APIs Components for iOS'
+        packageFilter: '*.nupkg'
+        dependsOn: [ 'build' ]
+
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
         dependsOn: [ 'build' ]
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+
+    - template: compliance/sbom/job.v1.yml@internal-templates
+      parameters:
+        artifactNames: ['nuget-signed']
+        packageName: 'Xamarin Google APIs Components for iOS'
+        packageFilter: '*.nupkg'
+        dependsOn: [ 'signing' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
       windowsImage: ''
       xcode: '13.1'
 
-  - ${{ if ne(variables['System.TeamProject'], 'devdiv') }}:
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))) }}:
     - template: compliance/sbom/job.v1.yml@internal-templates
       parameters:
         artifactNames: ['nuget']

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,24 +28,19 @@ jobs:
       windowsImage: ''
       xcode: '13.1'
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/'))) }}:
-    - template: compliance/sbom/job.v1.yml@internal-templates
-      parameters:
-        artifactNames: ['nuget']
-        packageName: 'Xamarin Google APIs Components for iOS'
-        packageFilter: '*.nupkg'
-        dependsOn: [ 'build' ]
-
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates
       parameters:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
-  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
     - template: compliance/sbom/job.v1.yml@internal-templates
       parameters:
-        artifactNames: ['nuget-signed']
         packageName: 'Xamarin Google APIs Components for iOS'
         packageFilter: '*.nupkg'
-        dependsOn: [ 'signing' ]
+        ${{ if not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
+          artifactNames: ['nuget']
+          dependsOn: [ 'build' ]
+        ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}:
+          artifactNames: ['nuget-signed']
+          dependsOn: [ 'signing' ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
-    - template: compliance/sbom/job.v1.yml@internal-templates
+    - template: compliance/sbom/job.v1.yml@internal-templates                 # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
       parameters:
         packageName: 'Xamarin Google APIs Components for iOS'
         packageFilter: '*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,10 +42,10 @@ jobs:
         dependsOn: [ 'build' ]
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
 
+  - ${{ if and(eq(variables['System.TeamProject'], 'devdiv'), startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}:
     - template: compliance/sbom/job.v1.yml@internal-templates
       parameters:
         artifactNames: ['nuget-signed']
         packageName: 'Xamarin Google APIs Components for iOS'
         packageFilter: '*.nupkg'
         dependsOn: [ 'signing' ]
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')


### PR DESCRIPTION
Per Executive Order (EO) produce a Software Bill of Materials (SBOM) capturing the produced nuget files from a dedicated job
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator

As a result of this change you will find an artifact named `sbom` attached to each build.  Within that artifact is a `manifest.json` file under a `_manifest` directory capturing all of the packages that constitute the `Software Bill of Materials` 

The `sbom` job captures the nuget package files (*.nupkg) published (uploaded) by the build