### PR TITLE
Use EO compliant pools for windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,8 @@ jobs:
       cakeExtraArgs: '--names=$(SdksNames)'
       windowsImage: ''
       xcode: '13.1'
+      windowsAgentPoolName: 'AzurePipelines-EO'
+      windowsImageOverride: 'AzurePipelinesWindows2022compliant'
 
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
     - template: sign-artifacts/jobs/v2.yml@internal-templates


### PR DESCRIPTION
Specifies the EO compliant windows pool for build for the [components build template](https://github.com/xamarin/XamarinComponents/blob/a704f839f1fd20ca64efa17bc3a5d51ae6885455/.ci/build.yml)

NOTE: I _think_ this is incomplete because we should also be using the EO compliant pool for linux, but there is not yet a capability to do so in the components template.