### PR TITLE
[ci] Fixed cake version to be used

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,7 @@ jobs:
       cakeExtraArgs: '--names=$(SdksNames)'
       windowsImage: ''
       xcode: '13.2'
+      cake: '0.33.0'
       initSteps:
         - task: UseDotNet@2
           displayName: install .NET $(DotNetVersion)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,8 +30,13 @@ jobs:
       xcode: '13.2'
       cake: '0.33.0'
       initSteps:
+        # Cake v0.33.0 uses this version
         - task: UseDotNet@2
-          displayName: install .NET $(DotNetVersion)
+          displayName: Install .NET 2.1.818
+          inputs:
+            version: '2.1.818'
+        - task: UseDotNet@2
+          displayName: Install .NET $(DotNetVersion)
           inputs:
             version: $(DotNetVersion)
         - pwsh: |


### PR DESCRIPTION
Xamarin Componets `build.yml` now uses Cake `v2.2.0`. We are still using the old but wise `v0.33.0`.