### PR TITLE
[Firebase/Auth] Fixed User.Reauthenticate signature

### DIFF
--- a/source/Firebase/Auth/ApiDefinition.cs
+++ b/source/Firebase/Auth/ApiDefinition.cs
@@ -924,10 +924,10 @@ namespace Firebase.Auth
 		[Export ("reloadWithCompletion:")]
 		void Reload ([NullAllowed] UserProfileChangeHandler completion);
 
-		// -(void)reauthenticateWithCredential:(FIRAuthCredential * _Nonnull)credential completion:(FIRUserProfileChangeCallback _Nullable)completion;
+		// -(void)reauthenticateWithCredential:(FIRAuthCredential * _Nonnull)credential completion:(FIRAuthDataResultCallback _Nullable)completion;
 		[Async]
 		[Export ("reauthenticateWithCredential:completion:")]
-		void Reauthenticate (AuthCredential credential, [NullAllowed] UserProfileChangeHandler completion);
+		void Reauthenticate (AuthCredential credential, [NullAllowed] AuthDataResultHandler completion);
 
 		// -(void)reauthenticateWithProvider:(id<FIRFederatedAuthProvider> _Nonnull)provider UIDelegate:(id<FIRAuthUIDelegate> _Nullable)UIDelegate completion:(FIRAuthDataResultCallback _Nullable)completion __attribute__((swift_name("reauthenticate(with:uiDelegate:completion:)"))) __attribute__((availability(ios, introduced=8.0)));
 		[Async]


### PR DESCRIPTION
Since Firebase Authentication v6.0.0 the `reauthenticate` method has been broken.
This results in the following issues:
* when provided with valid credentials a cast exception is thrown
#419
* when invalid credentials are provided the method doesn't throw the expected `NSErrorException`

### What happend

In Firebase Auth v5.1.0 the `reauthenticateWithCredential:completion:` method was [deprecated](https://github.com/firebase/firebase-ios-sdk/commit/d8e9113e67d9695aef605e89f3009db482a87fb2#diff-26a22213d72b20feb1c2b32702092d162e8ebdd6d7957fc16980380196c4506c).

In Firebase Auth v6.0.0 the signature of the deprecated `reauthenticateWithCredential:completion:` method was [changed](https://github.com/firebase/firebase-ios-sdk/commit/dae3442966b27c7f77a0021b995e97ba0c79f979#diff-26a22213d72b20feb1c2b32702092d162e8ebdd6d7957fc16980380196c4506c) to match `reauthenticateAndRetrieveDataWithCredential:completion` and the later was deprecated.

While [updating](https://github.com/xamarin/GoogleApisForiOSComponents/commit/98f16ab39b87bac5cccb44b2801148f55802aab8) from 5.8.1 to 6.5.0 the signature was never updated to reflect this change.

In Firebase Auth v7.0.0 the deprecated `reauthenticateAndRetrieveDataWithCredential:completion` method was [removed](https://github.com/firebase/firebase-ios-sdk/commit/14764b8d60a6ad023d8fa5b7f81d42378d92e6fe#diff-2f5f346eca4f8214f9b86a0ba062d6cce93623524334c1da207710ea7fe65f08).

So currently there is no working method to reauthenticate with credentials.
