### PR TITLE
Compress all binding resource packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,6 @@
         <BaseOutputPath>bin\$(MSBuildProjectName)\</BaseOutputPath>
         <BaseIntermediateOutputPath>obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
         <MSBuildProjectExtensionsPath>obj\$(MSBuildProjectName)\</MSBuildProjectExtensionsPath>
+        <CompressBindingResourcePackage>true</CompressBindingResourcePackage>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Compress all binding resource packages, to try to avoid MAX_PATH problems on
Windows.